### PR TITLE
fix(devspace): read env var defaults

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,10 +3,18 @@ version: v2beta1
 vars:
   APP_NAMESPACE: platform
   E2E_IMAGE: mcr.microsoft.com/playwright:v1.59.1-noble
-  ARGOS_TOKEN: ""
-  ARGOS_BRANCH: ""
-  ARGOS_COMMIT: ""
-  E2E_OIDC_REDIRECT_URI: ""
+  ARGOS_TOKEN:
+    source: env
+    default: ""
+  ARGOS_BRANCH:
+    source: env
+    default: ""
+  ARGOS_COMMIT:
+    source: env
+    default: ""
+  E2E_OIDC_REDIRECT_URI:
+    source: env
+    default: ""
 
 functions:
   disable_argocd_sync: |-


### PR DESCRIPTION
## Summary
- update DevSpace vars to read from environment with empty-string defaults so CI secrets are respected
- keep CI unset while allowing argos/E2E vars to resolve cleanly

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build

Refs #7