### PR TITLE
Add create organization empty state

### DIFF
--- a/src/components/CreateOrganizationDialog.tsx
+++ b/src/components/CreateOrganizationDialog.tsx
@@ -1,0 +1,72 @@
+import { Button } from '@/components/Button';
+import { Input } from '@/components/Input';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+type CreateOrganizationDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationName: string;
+  organizationNameError: string;
+  onOrganizationNameChange: (value: string) => void;
+  onSubmit: () => void;
+  isSubmitting: boolean;
+  testIdPrefix: string;
+};
+
+export function CreateOrganizationDialog({
+  open,
+  onOpenChange,
+  organizationName,
+  organizationNameError,
+  onOrganizationNameChange,
+  onSubmit,
+  isSubmitting,
+  testIdPrefix,
+}: CreateOrganizationDialogProps) {
+  const testId = (suffix: string) => `${testIdPrefix}-${suffix}`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid={testId('dialog')}>
+        <DialogHeader>
+          <DialogTitle data-testid={testId('title')}>Create organization</DialogTitle>
+          <DialogDescription data-testid={testId('description')}>Set the organization name.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Input
+            label="Organization Name"
+            placeholder="Acme AI"
+            value={organizationName}
+            onChange={(event) => onOrganizationNameChange(event.target.value)}
+            error={organizationNameError}
+            data-testid={testId('name')}
+          />
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" size="sm" data-testid={testId('cancel')}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onSubmit}
+            disabled={isSubmitting}
+            data-testid={testId('submit')}
+          >
+            {isSubmitting ? 'Creating...' : 'Create organization'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/useCreateOrganization.ts
+++ b/src/hooks/useCreateOrganization.ts
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { ConnectError } from '@connectrpc/connect';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { organizationsClient } from '@/api/client';
+import { toast } from 'sonner';
+
+type UseCreateOrganizationResult = {
+  open: boolean;
+  handleOpenChange: (open: boolean) => void;
+  organizationName: string;
+  organizationNameError: string;
+  handleNameChange: (value: string) => void;
+  handleSubmit: () => void;
+  isSubmitting: boolean;
+};
+
+export function useCreateOrganization(): UseCreateOrganizationResult {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [organizationName, setOrganizationName] = useState('');
+  const [organizationNameError, setOrganizationNameError] = useState('');
+
+  const resetState = () => {
+    setOrganizationName('');
+    setOrganizationNameError('');
+  };
+
+  const createOrganizationMutation = useMutation({
+    mutationFn: (payload: { name: string }) => organizationsClient.createOrganization(payload),
+    onSuccess: () => {
+      toast.success('Organization created.');
+      void queryClient.invalidateQueries({ queryKey: ['organizations', 'accessible'] });
+      void queryClient.invalidateQueries({ queryKey: ['organizations', 'memberships'] });
+      void queryClient.invalidateQueries({ queryKey: ['organizations', 'list'] });
+      setOpen(false);
+      resetState();
+    },
+    onError: (error) => {
+      if (error instanceof ConnectError) {
+        toast.error(error.message);
+        return;
+      }
+      toast.error('Failed to create organization.');
+    },
+  });
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      resetState();
+    }
+  };
+
+  const handleNameChange = (value: string) => {
+    setOrganizationName(value);
+    if (organizationNameError) {
+      setOrganizationNameError('');
+    }
+  };
+
+  const handleSubmit = () => {
+    const trimmedName = organizationName.trim();
+    if (!trimmedName) {
+      setOrganizationNameError('Organization name is required.');
+      return;
+    }
+    setOrganizationNameError('');
+    createOrganizationMutation.mutate({ name: trimmedName });
+  };
+
+  return {
+    open,
+    handleOpenChange,
+    organizationName,
+    organizationNameError,
+    handleNameChange,
+    handleSubmit,
+    isSubmitting: createOrganizationMutation.isPending,
+  };
+}

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
 import {
   ActivityIcon,
@@ -15,23 +14,13 @@ import {
   ServerIcon,
   UsersIcon,
 } from 'lucide-react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Toaster, toast } from 'sonner';
-import { organizationsClient } from '@/api/client';
+import { Toaster } from 'sonner';
 import { Button } from '@/components/Button';
-import { Input } from '@/components/Input';
+import { CreateOrganizationDialog } from '@/components/CreateOrganizationDialog';
 import { useOrganizationContext } from '@/context/OrganizationContext';
 import { useUserContext } from '@/context/UserContext';
 import { OrganizationSwitcher } from '@/components/OrganizationSwitcher';
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { useCreateOrganization } from '@/hooks/useCreateOrganization';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -46,47 +35,70 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
     isActive ? 'bg-[var(--agyn-bg-blue)] text-[var(--agyn-blue)]' : 'text-[var(--agyn-dark)] hover:bg-[var(--agyn-bg-light)]'
   }`;
 
+type NoAccessScreenProps = {
+  onSignOut: () => void;
+};
+
+function NoAccessScreen({ onSignOut }: NoAccessScreenProps) {
+  const {
+    open,
+    handleOpenChange,
+    organizationName,
+    organizationNameError,
+    handleNameChange,
+    handleSubmit,
+    isSubmitting,
+  } = useCreateOrganization();
+
+  return (
+    <>
+      <div
+        className="flex min-h-screen items-center justify-center bg-[var(--agyn-bg-light)] px-6"
+        data-testid="console-no-access"
+      >
+        <div className="max-w-lg rounded-xl border border-[var(--agyn-border-subtle)] bg-white p-8 text-center">
+          <h1 className="text-xl font-semibold text-[var(--agyn-dark)]">No organizations to manage</h1>
+          <p className="mt-2 text-sm text-[var(--agyn-gray)]">
+            Your account does not have console access yet. Contact a cluster admin or organization owner to
+            request access.
+          </p>
+          <div className="mt-4 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              size="sm"
+              onClick={() => handleOpenChange(true)}
+              data-testid="console-create-organization-button"
+            >
+              Create organization
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onSignOut}
+              data-testid="console-sign-out-button"
+            >
+              Sign out
+            </Button>
+          </div>
+        </div>
+      </div>
+      <CreateOrganizationDialog
+        open={open}
+        onOpenChange={handleOpenChange}
+        organizationName={organizationName}
+        organizationNameError={organizationNameError}
+        onOrganizationNameChange={handleNameChange}
+        onSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+        testIdPrefix="console-create-organization"
+      />
+      <Toaster richColors position="top-right" />
+    </>
+  );
+}
+
 export function AppLayout() {
   const { selectedOrganization, hasConsoleAccess, status: orgStatus } = useOrganizationContext();
   const { currentUser, isClusterAdmin, status: userStatus, error: userError, signOut } = useUserContext();
-  const queryClient = useQueryClient();
-  const [createOpen, setCreateOpen] = useState(false);
-  const [orgName, setOrgName] = useState('');
-  const [orgNameError, setOrgNameError] = useState('');
-
-  const createOrganizationMutation = useMutation({
-    mutationFn: (payload: { name: string }) => organizationsClient.createOrganization(payload),
-    onSuccess: () => {
-      toast.success('Organization created.');
-      void queryClient.invalidateQueries({ queryKey: ['organizations', 'accessible'] });
-      void queryClient.invalidateQueries({ queryKey: ['organizations', 'memberships'] });
-      void queryClient.invalidateQueries({ queryKey: ['organizations', 'list'] });
-      setCreateOpen(false);
-      setOrgName('');
-      setOrgNameError('');
-    },
-    onError: (err) => {
-      toast.error(err instanceof Error ? err.message : 'Failed to create organization.');
-    },
-  });
-
-  const handleCreateOrganization = () => {
-    const trimmedName = orgName.trim();
-    if (!trimmedName) {
-      setOrgNameError('Organization name is required.');
-      return;
-    }
-    setOrgNameError('');
-    createOrganizationMutation.mutate({ name: trimmedName });
-  };
-
-  const handleCreateOpenChange = (open: boolean) => {
-    setCreateOpen(open);
-    if (!open) {
-      setOrgName('');
-      setOrgNameError('');
-    }
-  };
 
   if (userStatus === 'loading' || orgStatus === 'loading') {
     return (
@@ -105,79 +117,7 @@ export function AppLayout() {
   }
 
   if (!hasConsoleAccess) {
-    return (
-      <>
-        <div
-          className="flex min-h-screen items-center justify-center bg-[var(--agyn-bg-light)] px-6"
-          data-testid="console-no-access"
-        >
-          <div className="max-w-lg rounded-xl border border-[var(--agyn-border-subtle)] bg-white p-8 text-center">
-            <h1 className="text-xl font-semibold text-[var(--agyn-dark)]">No organizations to manage</h1>
-            <p className="mt-2 text-sm text-[var(--agyn-gray)]">
-              Your account does not have console access yet. Contact a cluster admin or organization owner to
-              request access.
-            </p>
-            <div className="mt-4 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-              <Button
-                size="sm"
-                onClick={() => handleCreateOpenChange(true)}
-                data-testid="console-create-organization-button"
-              >
-                Create organization
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={signOut}
-                data-testid="console-sign-out-button"
-              >
-                Sign out
-              </Button>
-            </div>
-          </div>
-        </div>
-        <Dialog open={createOpen} onOpenChange={handleCreateOpenChange}>
-          <DialogContent data-testid="console-create-organization-dialog">
-            <DialogHeader>
-              <DialogTitle data-testid="console-create-organization-title">Create organization</DialogTitle>
-              <DialogDescription data-testid="console-create-organization-description">
-                Set the organization name.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-4">
-              <Input
-                label="Organization Name"
-                placeholder="Acme AI"
-                value={orgName}
-                onChange={(event) => {
-                  setOrgName(event.target.value);
-                  if (orgNameError) setOrgNameError('');
-                }}
-                error={orgNameError}
-                data-testid="console-create-organization-name"
-              />
-            </div>
-            <DialogFooter>
-              <DialogClose asChild>
-                <Button variant="outline" size="sm" data-testid="console-create-organization-cancel">
-                  Cancel
-                </Button>
-              </DialogClose>
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleCreateOrganization}
-                disabled={createOrganizationMutation.isPending}
-                data-testid="console-create-organization-submit"
-              >
-                {createOrganizationMutation.isPending ? 'Creating...' : 'Create organization'}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-        <Toaster richColors position="top-right" />
-      </>
-    );
+    return <NoAccessScreen onSignOut={signOut} />;
   }
 
   const origin = window.location.origin;

--- a/src/pages/OrganizationsListPage.tsx
+++ b/src/pages/OrganizationsListPage.tsx
@@ -1,26 +1,14 @@
-import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { BuildingIcon, PlusIcon } from 'lucide-react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { organizationsClient } from '@/api/client';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/Button';
 import { Card, CardContent } from '@/components/ui/card';
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/Input';
+import { CreateOrganizationDialog } from '@/components/CreateOrganizationDialog';
 import { useOrganizationContext } from '@/context/OrganizationContext';
 import { useUserContext } from '@/context/UserContext';
 import type { MembershipRole } from '@/gen/agynio/api/organizations/v1/organizations_pb';
+import { useCreateOrganization } from '@/hooks/useCreateOrganization';
 import { formatDateOnly, formatMembershipRole } from '@/lib/format';
-import { toast } from 'sonner';
 
 function describeRole(role?: MembershipRole, isClusterAdmin?: boolean): string {
   if (!role) return isClusterAdmin ? 'Admin' : '—';
@@ -30,44 +18,15 @@ function describeRole(role?: MembershipRole, isClusterAdmin?: boolean): string {
 export function OrganizationsListPage() {
   const { organizations, status, error } = useOrganizationContext();
   const { isClusterAdmin } = useUserContext();
-  const queryClient = useQueryClient();
-  const [createOpen, setCreateOpen] = useState(false);
-  const [orgName, setOrgName] = useState('');
-  const [orgNameError, setOrgNameError] = useState('');
-
-  const createOrganizationMutation = useMutation({
-    mutationFn: (payload: { name: string }) => organizationsClient.createOrganization(payload),
-    onSuccess: () => {
-      toast.success('Organization created.');
-      void queryClient.invalidateQueries({ queryKey: ['organizations', 'accessible'] });
-      void queryClient.invalidateQueries({ queryKey: ['organizations', 'memberships'] });
-      void queryClient.invalidateQueries({ queryKey: ['organizations', 'list'] });
-      setCreateOpen(false);
-      setOrgName('');
-      setOrgNameError('');
-    },
-    onError: (err) => {
-      toast.error(err instanceof Error ? err.message : 'Failed to create organization.');
-    },
-  });
-
-  const handleCreateOrganization = () => {
-    const trimmedName = orgName.trim();
-    if (!trimmedName) {
-      setOrgNameError('Organization name is required.');
-      return;
-    }
-    setOrgNameError('');
-    createOrganizationMutation.mutate({ name: trimmedName });
-  };
-
-  const handleCreateOpenChange = (open: boolean) => {
-    setCreateOpen(open);
-    if (!open) {
-      setOrgName('');
-      setOrgNameError('');
-    }
-  };
+  const {
+    open: createOpen,
+    handleOpenChange,
+    organizationName,
+    organizationNameError,
+    handleNameChange,
+    handleSubmit,
+    isSubmitting,
+  } = useCreateOrganization();
 
   return (
     <div className="space-y-6">
@@ -83,7 +42,7 @@ export function OrganizationsListPage() {
             variant="outline"
             size="sm"
             data-testid="organizations-create-button"
-            onClick={() => handleCreateOpenChange(true)}
+            onClick={() => handleOpenChange(true)}
           >
             <PlusIcon className="mr-2 h-4 w-4" />
             Create organization
@@ -146,45 +105,16 @@ export function OrganizationsListPage() {
           </CardContent>
         </Card>
       ) : null}
-      <Dialog open={createOpen} onOpenChange={handleCreateOpenChange}>
-        <DialogContent data-testid="organizations-create-dialog">
-          <DialogHeader>
-            <DialogTitle data-testid="organizations-create-title">Create organization</DialogTitle>
-            <DialogDescription data-testid="organizations-create-description">
-              Set the organization name.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            <Input
-              label="Organization Name"
-              placeholder="Acme AI"
-              value={orgName}
-              onChange={(event) => {
-                setOrgName(event.target.value);
-                if (orgNameError) setOrgNameError('');
-              }}
-              error={orgNameError}
-              data-testid="organizations-create-name"
-            />
-          </div>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button variant="outline" size="sm" data-testid="organizations-create-cancel">
-                Cancel
-              </Button>
-            </DialogClose>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={handleCreateOrganization}
-              disabled={createOrganizationMutation.isPending}
-              data-testid="organizations-create-submit"
-            >
-              {createOrganizationMutation.isPending ? 'Creating...' : 'Create organization'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <CreateOrganizationDialog
+        open={createOpen}
+        onOpenChange={handleOpenChange}
+        organizationName={organizationName}
+        organizationNameError={organizationNameError}
+        onOrganizationNameChange={handleNameChange}
+        onSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+        testIdPrefix="organizations-create"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a create-organization dialog to the no-access empty state
- wire create mutation with query invalidation + toasts
- add test ids and toast support for the empty-state flow

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #20