### PR TITLE
Fix query key collisions for infinite lists

### DIFF
--- a/src/components/InstallAppDialog.tsx
+++ b/src/components/InstallAppDialog.tsx
@@ -38,7 +38,7 @@ export function InstallAppDialog({ open, onOpenChange, organizationId }: Install
   const [configurationError, setConfigurationError] = useState('');
 
   const appsQuery = useQuery({
-    queryKey: ['apps', 'list'],
+    queryKey: ['apps', 'list', 'all'],
     queryFn: () => appsClient.listApps({ pageSize: MAX_PAGE_SIZE, pageToken: '' }),
     enabled: open,
     staleTime: 60_000,

--- a/src/pages/AgentCreatePage.tsx
+++ b/src/pages/AgentCreatePage.tsx
@@ -34,7 +34,7 @@ export function AgentCreatePage() {
   const [resources, setResources] = useState<ComputeResources | undefined>(undefined);
 
   const modelsQuery = useQuery({
-    queryKey: ['llm', organizationId, 'models'],
+    queryKey: ['llm', organizationId, 'models', 'all'],
     queryFn: () => llmClient.listModels({ organizationId, pageSize: MAX_PAGE_SIZE, pageToken: '' }),
     enabled: Boolean(organizationId),
     staleTime: 60_000,

--- a/src/pages/AppsPage.tsx
+++ b/src/pages/AppsPage.tsx
@@ -20,7 +20,7 @@ export function AppsPage() {
   const [registerOpen, setRegisterOpen] = useState(false);
 
   const appsQuery = useInfiniteQuery({
-    queryKey: ['apps', 'list'],
+    queryKey: ['apps', 'list', 'infinite'],
     queryFn: ({ pageParam }) => appsClient.listApps({ pageSize: DEFAULT_PAGE_SIZE, pageToken: pageParam }),
     initialPageParam: '',
     getNextPageParam: (lastPage) => lastPage.nextPageToken || undefined,

--- a/src/pages/OrganizationAgentsTab.tsx
+++ b/src/pages/OrganizationAgentsTab.tsx
@@ -31,7 +31,7 @@ export function OrganizationAgentsTab() {
   });
 
   const modelsQuery = useQuery({
-    queryKey: ['llm', organizationId, 'models'],
+    queryKey: ['llm', organizationId, 'models', 'all'],
     queryFn: () => llmClient.listModels({ organizationId, pageSize: MAX_PAGE_SIZE, pageToken: '' }),
     enabled: Boolean(organizationId),
     staleTime: 60_000,

--- a/src/pages/OrganizationImagePullSecretsTab.tsx
+++ b/src/pages/OrganizationImagePullSecretsTab.tsx
@@ -369,7 +369,7 @@ export function OrganizationImagePullSecretsTab() {
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const providersQuery = useQuery({
-    queryKey: ['secrets', organizationId, 'providers'],
+    queryKey: ['secrets', organizationId, 'providers', 'all'],
     queryFn: () => secretsClient.listSecretProviders({ organizationId, pageSize: MAX_PAGE_SIZE, pageToken: '' }),
     enabled: Boolean(organizationId),
     staleTime: 60_000,
@@ -377,7 +377,7 @@ export function OrganizationImagePullSecretsTab() {
   });
 
   const imagePullSecretsQuery = useInfiniteQuery({
-    queryKey: ['imagePullSecrets', organizationId, 'list'],
+    queryKey: ['imagePullSecrets', organizationId, 'list', 'infinite'],
     queryFn: ({ pageParam }) =>
       secretsClient.listImagePullSecrets({ organizationId, pageSize: DEFAULT_PAGE_SIZE, pageToken: pageParam }),
     initialPageParam: '',

--- a/src/pages/OrganizationLlmProvidersTab.tsx
+++ b/src/pages/OrganizationLlmProvidersTab.tsx
@@ -47,7 +47,7 @@ export function OrganizationLlmProvidersTab() {
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const providersQuery = useInfiniteQuery({
-    queryKey: ['llm', organizationId, 'providers'],
+    queryKey: ['llm', organizationId, 'providers', 'infinite'],
     queryFn: ({ pageParam }) =>
       llmClient.listLLMProviders({ organizationId, pageSize: DEFAULT_PAGE_SIZE, pageToken: pageParam }),
     initialPageParam: '',

--- a/src/pages/OrganizationModelsTab.tsx
+++ b/src/pages/OrganizationModelsTab.tsx
@@ -50,7 +50,7 @@ export function OrganizationModelsTab() {
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const modelsQuery = useInfiniteQuery({
-    queryKey: ['llm', organizationId, 'models'],
+    queryKey: ['llm', organizationId, 'models', 'infinite'],
     queryFn: ({ pageParam }) =>
       llmClient.listModels({ organizationId, pageSize: DEFAULT_PAGE_SIZE, pageToken: pageParam }),
     initialPageParam: '',
@@ -61,7 +61,7 @@ export function OrganizationModelsTab() {
   });
 
   const providersQuery = useQuery({
-    queryKey: ['llm', organizationId, 'providers'],
+    queryKey: ['llm', organizationId, 'providers', 'all'],
     queryFn: () => llmClient.listLLMProviders({ organizationId, pageSize: MAX_PAGE_SIZE, pageToken: '' }),
     enabled: Boolean(organizationId),
     staleTime: 60_000,

--- a/src/pages/OrganizationSecretProvidersTab.tsx
+++ b/src/pages/OrganizationSecretProvidersTab.tsx
@@ -53,7 +53,7 @@ export function OrganizationSecretProvidersTab() {
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const providersQuery = useInfiniteQuery({
-    queryKey: ['secrets', organizationId, 'providers'],
+    queryKey: ['secrets', organizationId, 'providers', 'infinite'],
     queryFn: ({ pageParam }) =>
       secretsClient.listSecretProviders({ organizationId, pageSize: DEFAULT_PAGE_SIZE, pageToken: pageParam }),
     initialPageParam: '',

--- a/src/pages/OrganizationSecretsTab.tsx
+++ b/src/pages/OrganizationSecretsTab.tsx
@@ -52,7 +52,7 @@ export function OrganizationSecretsTab() {
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const providersQuery = useQuery({
-    queryKey: ['secrets', organizationId, 'providers'],
+    queryKey: ['secrets', organizationId, 'providers', 'all'],
     queryFn: () => secretsClient.listSecretProviders({ organizationId, pageSize: MAX_PAGE_SIZE, pageToken: '' }),
     enabled: Boolean(organizationId),
     staleTime: 60 * 1000,
@@ -60,7 +60,7 @@ export function OrganizationSecretsTab() {
   });
 
   const secretsQuery = useInfiniteQuery({
-    queryKey: ['secrets', organizationId, 'list'],
+    queryKey: ['secrets', organizationId, 'list', 'infinite'],
     queryFn: ({ pageParam }) =>
       secretsClient.listSecrets({
         organizationId,

--- a/src/pages/OrganizationVolumesTab.tsx
+++ b/src/pages/OrganizationVolumesTab.tsx
@@ -50,7 +50,7 @@ export function OrganizationVolumesTab() {
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const volumesQuery = useInfiniteQuery({
-    queryKey: ['volumes', organizationId, 'list'],
+    queryKey: ['volumes', organizationId, 'list', 'infinite'],
     queryFn: ({ pageParam }) =>
       agentsClient.listVolumes({ organizationId, pageSize: DEFAULT_PAGE_SIZE, pageToken: pageParam }),
     initialPageParam: '',

--- a/src/pages/agent-detail/AgentConfigurationTab.tsx
+++ b/src/pages/agent-detail/AgentConfigurationTab.tsx
@@ -49,7 +49,7 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
   const [resources, setResources] = useState<ComputeResources | undefined>(undefined);
 
   const modelsQuery = useQuery({
-    queryKey: ['llm', organizationId, 'models'],
+    queryKey: ['llm', organizationId, 'models', 'all'],
     queryFn: () => llmClient.listModels({ organizationId, pageSize: MAX_PAGE_SIZE, pageToken: '' }),
     enabled: Boolean(organizationId),
     staleTime: 60_000,

--- a/src/pages/agent-detail/AgentEnvsTab.tsx
+++ b/src/pages/agent-detail/AgentEnvsTab.tsx
@@ -61,7 +61,7 @@ export function AgentEnvsTab({ agentId, organizationId }: AgentEnvsTabProps) {
   });
 
   const secretsQuery = useQuery({
-    queryKey: ['secrets', organizationId, 'list'],
+    queryKey: ['secrets', organizationId, 'list', 'all'],
     queryFn: () =>
       secretsClient.listSecrets({
         organizationId,

--- a/src/pages/agent-detail/AgentImagePullSecretsTab.tsx
+++ b/src/pages/agent-detail/AgentImagePullSecretsTab.tsx
@@ -53,7 +53,7 @@ export function AgentImagePullSecretsTab({ agentId, organizationId }: AgentImage
   });
 
   const imagePullSecretsQuery = useQuery({
-    queryKey: ['imagePullSecrets', organizationId, 'list'],
+    queryKey: ['imagePullSecrets', organizationId, 'list', 'all'],
     queryFn: () => secretsClient.listImagePullSecrets({ organizationId, pageSize: MAX_PAGE_SIZE, pageToken: '' }),
     enabled: Boolean(organizationId),
     staleTime: 60_000,

--- a/src/pages/agent-detail/AgentVolumeAttachmentsTab.tsx
+++ b/src/pages/agent-detail/AgentVolumeAttachmentsTab.tsx
@@ -44,7 +44,7 @@ export function AgentVolumeAttachmentsTab({ agentId, organizationId }: AgentVolu
   });
 
   const volumesQuery = useQuery({
-    queryKey: ['volumes', organizationId, 'list'],
+    queryKey: ['volumes', organizationId, 'list', 'all'],
     queryFn: () => agentsClient.listVolumes({ organizationId, pageSize: MAX_PAGE_SIZE, pageToken: '' }),
     enabled: Boolean(organizationId),
     staleTime: 60_000,


### PR DESCRIPTION
## Summary
- disambiguate infinite vs non-infinite query keys for apps, volumes, secrets, image pull secrets, and LLM data
- keep invalidations using base prefixes so related queries stay in sync

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #37