### PR TITLE
test(e2e): cover devices page

### DIFF
--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -37,6 +37,13 @@ type RunnerWire = {
   status?: string | number;
 };
 
+type DeviceWire = {
+  meta?: { id?: string; createdAt?: string };
+  name?: string;
+  status?: string | number;
+  enrollmentJwt?: string;
+};
+
 type CreateOrganizationResponseWire = {
   organization?: { id?: string };
 };
@@ -95,6 +102,15 @@ type CreateSecretResponseWire = {
 
 type ListSecretsResponseWire = {
   secrets?: SecretWire[];
+};
+
+type CreateDeviceResponseWire = {
+  device?: DeviceWire;
+  enrollmentJwt?: string;
+};
+
+type ListDevicesResponseWire = {
+  devices?: DeviceWire[];
 };
 
 type ListRunnersResponseWire = {
@@ -504,6 +520,33 @@ export async function clearOrganizationSecrets(page: Page, organizationId: strin
     await page.waitForTimeout(500);
   }
   throw new Error('Timed out clearing organization secrets.');
+}
+
+export async function createDevice(page: Page, opts: { name: string }): Promise<CreateDeviceResponseWire> {
+  const response = await postConnect<CreateDeviceResponseWire>(page, USERS_GATEWAY_PATH, 'CreateDevice', {
+    name: opts.name,
+  });
+  if (!response.device?.meta?.id) {
+    throw new Error('CreateDevice response missing device id.');
+  }
+  return response;
+}
+
+export async function listDevices(page: Page): Promise<DeviceWire[]> {
+  const response = await postConnect<ListDevicesResponseWire>(page, USERS_GATEWAY_PATH, 'ListDevices', {
+    pageSize: 200,
+    pageToken: '',
+  });
+  return response.devices ?? [];
+}
+
+export async function deleteDevice(page: Page, deviceId: string): Promise<void> {
+  try {
+    await postConnect(page, USERS_GATEWAY_PATH, 'DeleteDevice', { id: deviceId });
+  } catch (error) {
+    if (isNotFoundError(error)) return;
+    throw error;
+  }
 }
 
 export async function listRunners(page: Page): Promise<RunnerWire[]> {

--- a/test/e2e/devices.spec.ts
+++ b/test/e2e/devices.spec.ts
@@ -1,0 +1,76 @@
+import { argosScreenshot } from '@argos-ci/playwright';
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+import { createDevice, deleteDevice, listDevices } from './console-api';
+
+const DEVICE_NAME_PREFIX = 'e2e-device';
+
+const buildDeviceName = (suffix: string) => `${DEVICE_NAME_PREFIX}-${suffix}-${Date.now()}`;
+
+async function cleanupDevices(page: Page): Promise<void> {
+  const devices = await listDevices(page);
+  const deviceIds = devices
+    .filter((device) => device.name?.startsWith(DEVICE_NAME_PREFIX))
+    .map((device) => device.meta?.id)
+    .filter((deviceId): deviceId is string => Boolean(deviceId));
+  await Promise.all(deviceIds.map((deviceId) => deleteDevice(page, deviceId)));
+}
+
+test.beforeEach(async ({ page }) => {
+  await cleanupDevices(page);
+});
+
+test.afterEach(async ({ page }) => {
+  await cleanupDevices(page);
+});
+
+test('shows empty devices page', async ({ page }) => {
+  await page.goto('/devices');
+  await expect(page.getByTestId('list-search')).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId('devices-empty')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'devices-empty');
+});
+
+test('creates a device and shows enrollment JWT', async ({ page }) => {
+  const deviceName = buildDeviceName('jwt');
+
+  await page.goto('/devices');
+  await expect(page.getByTestId('list-search')).toBeVisible({ timeout: 15000 });
+
+  await page.getByTestId('devices-create').click();
+  await expect(page.getByTestId('devices-create-dialog')).toBeVisible({ timeout: 15000 });
+
+  await page.getByTestId('devices-name').fill(deviceName);
+  await page.getByTestId('devices-submit').click();
+
+  await expect(page.getByTestId('devices-jwt-value')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'devices-create-jwt');
+
+  await page.getByTestId('devices-jwt-done').click();
+
+  const deviceRow = page.getByTestId('devices-row').filter({ hasText: deviceName });
+  await expect(deviceRow).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'devices-list');
+});
+
+test('deletes a device with confirmation', async ({ page }) => {
+  const deviceName = buildDeviceName('delete');
+  const created = await createDevice(page, { name: deviceName });
+  const deviceId = created.device?.meta?.id;
+  if (!deviceId) {
+    throw new Error('CreateDevice response missing device id for delete test.');
+  }
+
+  await page.goto('/devices');
+  await expect(page.getByTestId('list-search')).toBeVisible({ timeout: 15000 });
+
+  const deviceRow = page.getByTestId('devices-row').filter({ hasText: deviceName });
+  await expect(deviceRow).toBeVisible({ timeout: 15000 });
+
+  await deviceRow.getByTestId('devices-delete').click();
+  await expect(page.getByTestId('confirm-dialog')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'devices-delete-confirm');
+
+  await page.getByTestId('confirm-dialog-confirm').click();
+  await expect(deviceRow).toHaveCount(0, { timeout: 15000 });
+});


### PR DESCRIPTION
## Summary
- add device API helpers for create/list/delete in e2e console API
- add devices e2e specs for empty state, JWT display, and delete confirmation with cleanup

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #42