### PR TITLE
test(e2e): capture sign-out screenshots

### DIFF
--- a/test/e2e/sign-out.spec.ts
+++ b/test/e2e/sign-out.spec.ts
@@ -1,3 +1,4 @@
+import { argosScreenshot } from '@argos-ci/playwright';
 import { test, expect } from './fixtures';
 import { readOidcSession } from './oidc-helpers';
 
@@ -16,6 +17,9 @@ test('signs out from user menu', async ({ page }) => {
     }
     return true;
   }, { timeout: 20000 });
+
+  await page.waitForLoadState('networkidle');
+  await argosScreenshot(page, 'sign-out-user-menu');
 });
 
 test('signs out from settings page', async ({ page }) => {
@@ -33,4 +37,7 @@ test('signs out from settings page', async ({ page }) => {
     }
     return true;
   }, { timeout: 20000 });
+
+  await page.waitForLoadState('networkidle');
+  await argosScreenshot(page, 'sign-out-settings-page');
 });


### PR DESCRIPTION
## Summary
- wait for post-sign-out redirect to settle before capturing Argos screenshots in sign-out e2e tests
- add Argos snapshots for user-menu and settings sign-out flows

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build
- E2E_BASE_URL=http://127.0.0.1:5000 E2E_OIDC_AUTHORITY=http://127.0.0.1:5000 E2E_OIDC_CLIENT_ID=console-app E2E_OIDC_SCOPE='openid profile email' npm run test:e2e

Closes #45