### PR TITLE
feat(ui): add MCP/Hook image pull secrets

### DIFF
--- a/src/pages/AgentDetailPage.tsx
+++ b/src/pages/AgentDetailPage.tsx
@@ -76,13 +76,13 @@ export function AgentDetailPage() {
             <AgentConfigurationTab agent={agent} organizationId={organizationId} />
           </section>
           <section data-testid="agent-detail-section-mcps">
-            <AgentMcpsTab agentId={resolvedAgentId} />
+            <AgentMcpsTab agentId={resolvedAgentId} organizationId={organizationId} />
           </section>
           <section data-testid="agent-detail-section-skills">
             <AgentSkillsTab agentId={resolvedAgentId} />
           </section>
           <section data-testid="agent-detail-section-hooks">
-            <AgentHooksTab agentId={resolvedAgentId} />
+            <AgentHooksTab agentId={resolvedAgentId} organizationId={organizationId} />
           </section>
           <section data-testid="agent-detail-section-envs">
             <AgentEnvsTab agentId={resolvedAgentId} organizationId={organizationId} />

--- a/src/pages/agent-detail/AgentHooksTab.tsx
+++ b/src/pages/agent-detail/AgentHooksTab.tsx
@@ -23,14 +23,16 @@ import { useListControls } from '@/hooks/useListControls';
 import { formatDateOnly, timestampToMillis, truncate } from '@/lib/format';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
 import { NestedEnvsDialog } from '@/pages/agent-detail/NestedEnvsDialog';
+import { NestedImagePullSecretsDialog } from '@/pages/agent-detail/NestedImagePullSecretsDialog';
 import { NestedInitScriptsDialog } from '@/pages/agent-detail/NestedInitScriptsDialog';
 import { toast } from 'sonner';
 
 type AgentHooksTabProps = {
   agentId: string;
+  organizationId: string;
 };
 
-export function AgentHooksTab({ agentId }: AgentHooksTabProps) {
+export function AgentHooksTab({ agentId, organizationId }: AgentHooksTabProps) {
   const queryClient = useQueryClient();
   const [createOpen, setCreateOpen] = useState(false);
   const [createEvent, setCreateEvent] = useState('');
@@ -53,6 +55,7 @@ export function AgentHooksTab({ agentId }: AgentHooksTabProps) {
   const [editImageError, setEditImageError] = useState('');
   const [envTargetId, setEnvTargetId] = useState<string | null>(null);
   const [initTargetId, setInitTargetId] = useState<string | null>(null);
+  const [imagePullSecretsTargetId, setImagePullSecretsTargetId] = useState<string | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const hooksQuery = useQuery({
@@ -232,6 +235,15 @@ export function AgentHooksTab({ agentId }: AgentHooksTabProps) {
     setInitTargetId(hookId);
   };
 
+  const handleImagePullSecretsOpen = (hook: Hook) => {
+    const hookId = hook.meta?.id;
+    if (!hookId) {
+      toast.error('Missing hook ID.');
+      return;
+    }
+    setImagePullSecretsTargetId(hookId);
+  };
+
   const handleDeleteOpen = (hook: Hook) => {
     const hookId = hook.meta?.id;
     if (!hookId) {
@@ -265,6 +277,12 @@ export function AgentHooksTab({ agentId }: AgentHooksTabProps) {
   const handleInitOpenChange = (open: boolean) => {
     if (!open) {
       setInitTargetId(null);
+    }
+  };
+
+  const handleImagePullSecretsOpenChange = (open: boolean) => {
+    if (!open) {
+      setImagePullSecretsTargetId(null);
     }
   };
 
@@ -378,6 +396,12 @@ export function AgentHooksTab({ agentId }: AgentHooksTabProps) {
                         </DropdownMenuItem>
                         <DropdownMenuItem onSelect={() => handleInitOpen(hook)} data-testid="agent-hook-init-scripts">
                           Init Scripts
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onSelect={() => handleImagePullSecretsOpen(hook)}
+                          data-testid="agent-hook-image-pull-secrets"
+                        >
+                          Image Pull Secrets
                         </DropdownMenuItem>
                         <DropdownMenuItem onSelect={() => handleDeleteOpen(hook)} data-testid="agent-hook-delete">
                           Delete
@@ -573,6 +597,16 @@ export function AgentHooksTab({ agentId }: AgentHooksTabProps) {
         onOpenChange={handleInitOpenChange}
         title="Init Scripts"
         description="Manage hook init scripts."
+      />
+
+      <NestedImagePullSecretsDialog
+        targetCase="hookId"
+        targetId={imagePullSecretsTargetId}
+        organizationId={organizationId}
+        open={Boolean(imagePullSecretsTargetId)}
+        onOpenChange={handleImagePullSecretsOpenChange}
+        title="Image Pull Secrets"
+        description="Manage hook image pull secrets."
       />
 
       <ConfirmDialog

--- a/src/pages/agent-detail/AgentMcpsTab.tsx
+++ b/src/pages/agent-detail/AgentMcpsTab.tsx
@@ -23,14 +23,16 @@ import { useListControls } from '@/hooks/useListControls';
 import { formatDateOnly, timestampToMillis, truncate } from '@/lib/format';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
 import { NestedEnvsDialog } from '@/pages/agent-detail/NestedEnvsDialog';
+import { NestedImagePullSecretsDialog } from '@/pages/agent-detail/NestedImagePullSecretsDialog';
 import { NestedInitScriptsDialog } from '@/pages/agent-detail/NestedInitScriptsDialog';
 import { toast } from 'sonner';
 
 type AgentMcpsTabProps = {
   agentId: string;
+  organizationId: string;
 };
 
-export function AgentMcpsTab({ agentId }: AgentMcpsTabProps) {
+export function AgentMcpsTab({ agentId, organizationId }: AgentMcpsTabProps) {
   const queryClient = useQueryClient();
   const [createOpen, setCreateOpen] = useState(false);
   const [createName, setCreateName] = useState('');
@@ -50,6 +52,7 @@ export function AgentMcpsTab({ agentId }: AgentMcpsTabProps) {
   const [editImageError, setEditImageError] = useState('');
   const [envTargetId, setEnvTargetId] = useState<string | null>(null);
   const [initTargetId, setInitTargetId] = useState<string | null>(null);
+  const [imagePullSecretsTargetId, setImagePullSecretsTargetId] = useState<string | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const mcpsQuery = useQuery({
@@ -212,6 +215,15 @@ export function AgentMcpsTab({ agentId }: AgentMcpsTabProps) {
     setInitTargetId(mcpId);
   };
 
+  const handleImagePullSecretsOpen = (mcp: Mcp) => {
+    const mcpId = mcp.meta?.id;
+    if (!mcpId) {
+      toast.error('Missing MCP ID.');
+      return;
+    }
+    setImagePullSecretsTargetId(mcpId);
+  };
+
   const handleDeleteOpen = (mcp: Mcp) => {
     const mcpId = mcp.meta?.id;
     if (!mcpId) {
@@ -243,6 +255,12 @@ export function AgentMcpsTab({ agentId }: AgentMcpsTabProps) {
   const handleInitOpenChange = (open: boolean) => {
     if (!open) {
       setInitTargetId(null);
+    }
+  };
+
+  const handleImagePullSecretsOpenChange = (open: boolean) => {
+    if (!open) {
+      setImagePullSecretsTargetId(null);
     }
   };
 
@@ -356,6 +374,12 @@ export function AgentMcpsTab({ agentId }: AgentMcpsTabProps) {
                         </DropdownMenuItem>
                         <DropdownMenuItem onSelect={() => handleInitOpen(mcp)} data-testid="agent-mcp-init-scripts">
                           Init Scripts
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onSelect={() => handleImagePullSecretsOpen(mcp)}
+                          data-testid="agent-mcp-image-pull-secrets"
+                        >
+                          Image Pull Secrets
                         </DropdownMenuItem>
                         <DropdownMenuItem onSelect={() => handleDeleteOpen(mcp)} data-testid="agent-mcp-delete">
                           Delete
@@ -538,6 +562,16 @@ export function AgentMcpsTab({ agentId }: AgentMcpsTabProps) {
         onOpenChange={handleInitOpenChange}
         title="Init Scripts"
         description="Manage MCP init scripts."
+      />
+
+      <NestedImagePullSecretsDialog
+        targetCase="mcpId"
+        targetId={imagePullSecretsTargetId}
+        organizationId={organizationId}
+        open={Boolean(imagePullSecretsTargetId)}
+        onOpenChange={handleImagePullSecretsOpenChange}
+        title="Image Pull Secrets"
+        description="Manage MCP image pull secrets."
       />
 
       <ConfirmDialog

--- a/src/pages/agent-detail/NestedImagePullSecretsDialog.tsx
+++ b/src/pages/agent-detail/NestedImagePullSecretsDialog.tsx
@@ -197,10 +197,10 @@ export function NestedImagePullSecretsDialog({
                 if (selectedSecretError) setSelectedSecretError('');
               }}
             >
-            <SelectTrigger id="nested-image-pull-secrets-select" data-testid="nested-image-pull-secrets-select">
-              <SelectValue placeholder="Select secret" />
-            </SelectTrigger>
-            <SelectContent>
+              <SelectTrigger id="nested-image-pull-secrets-select" data-testid="nested-image-pull-secrets-select">
+                <SelectValue placeholder="Select secret" />
+              </SelectTrigger>
+              <SelectContent>
                 {availableSecrets.map((secret) => {
                   const secretId = secret.meta?.id;
                   if (!secretId) return null;

--- a/src/pages/agent-detail/NestedImagePullSecretsDialog.tsx
+++ b/src/pages/agent-detail/NestedImagePullSecretsDialog.tsx
@@ -1,0 +1,281 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { agentsClient, secretsClient } from '@/api/client';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { ImagePullSecretAttachment } from '@/gen/agynio/api/agents/v1/agents_pb';
+import type { ImagePullSecret } from '@/gen/agynio/api/secrets/v1/secrets_pb';
+import { MAX_PAGE_SIZE } from '@/lib/pagination';
+import { toast } from 'sonner';
+
+const EMPTY_ATTACHMENTS: ImagePullSecretAttachment[] = [];
+const EMPTY_SECRETS: ImagePullSecret[] = [];
+
+type NestedImagePullSecretsDialogProps = {
+  targetCase: 'mcpId' | 'hookId';
+  targetId: string | null;
+  organizationId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+  description?: string;
+};
+
+export function NestedImagePullSecretsDialog({
+  targetCase,
+  targetId,
+  organizationId,
+  open,
+  onOpenChange,
+  title = 'Image Pull Secrets',
+  description = 'Manage image pull secrets.',
+}: NestedImagePullSecretsDialogProps) {
+  const queryClient = useQueryClient();
+  const [selectedSecretId, setSelectedSecretId] = useState('');
+  const [selectedSecretError, setSelectedSecretError] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedSecretId('');
+    setSelectedSecretError('');
+  }, [open, targetId]);
+
+  const attachmentsQuery = useQuery({
+    queryKey: ['imagePullSecretAttachments', targetCase, targetId, 'list'],
+    queryFn: () => {
+      if (!targetId) {
+        return Promise.reject(new Error('Missing target ID.'));
+      }
+      return targetCase === 'mcpId'
+        ? agentsClient.listImagePullSecretAttachments({ mcpId: targetId, pageSize: MAX_PAGE_SIZE, pageToken: '' })
+        : agentsClient.listImagePullSecretAttachments({ hookId: targetId, pageSize: MAX_PAGE_SIZE, pageToken: '' });
+    },
+    enabled: Boolean(targetId),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const imagePullSecretsQuery = useQuery({
+    queryKey: ['imagePullSecrets', organizationId, 'list', 'all'],
+    queryFn: () => secretsClient.listImagePullSecrets({ organizationId, pageSize: MAX_PAGE_SIZE, pageToken: '' }),
+    enabled: Boolean(organizationId),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const attachments = attachmentsQuery.data?.imagePullSecretAttachments ?? EMPTY_ATTACHMENTS;
+  const secrets = imagePullSecretsQuery.data?.imagePullSecrets ?? EMPTY_SECRETS;
+
+  const secretMap = useMemo(() => {
+    return new Map(
+      secrets.flatMap((secret) => {
+        const secretId = secret.meta?.id;
+        return secretId ? ([[secretId, secret]] as const) : [];
+      }),
+    );
+  }, [secrets]);
+
+  const attachedSecretIds = useMemo(() => {
+    return new Set(attachments.map((attachment) => attachment.imagePullSecretId));
+  }, [attachments]);
+
+  const availableSecrets = useMemo(() => {
+    return secrets.filter((secret) => {
+      const secretId = secret.meta?.id;
+      if (!secretId) return false;
+      return !attachedSecretIds.has(secretId);
+    });
+  }, [secrets, attachedSecretIds]);
+
+  const createAttachmentMutation = useMutation({
+    mutationFn: (payload: {
+      imagePullSecretId: string;
+      target: { case: 'mcpId'; value: string } | { case: 'hookId'; value: string };
+    }) => agentsClient.createImagePullSecretAttachment(payload),
+    onSuccess: () => {
+      toast.success('Image pull secret attached.');
+      if (targetId) {
+        void queryClient.invalidateQueries({ queryKey: ['imagePullSecretAttachments', targetCase, targetId, 'list'] });
+      }
+      setSelectedSecretId('');
+      setSelectedSecretError('');
+    },
+    onError: (error) => {
+      if (error instanceof ConnectError && error.code === Code.AlreadyExists) {
+        toast.error('Image pull secret already attached.');
+        return;
+      }
+      toast.error(error instanceof Error ? error.message : 'Failed to attach image pull secret.');
+    },
+  });
+
+  const deleteAttachmentMutation = useMutation({
+    mutationFn: (attachmentId: string) => agentsClient.deleteImagePullSecretAttachment({ id: attachmentId }),
+    onSuccess: () => {
+      toast.success('Image pull secret detached.');
+      if (targetId) {
+        void queryClient.invalidateQueries({ queryKey: ['imagePullSecretAttachments', targetCase, targetId, 'list'] });
+      }
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : 'Failed to detach image pull secret.');
+    },
+  });
+
+  const handleAttach = () => {
+    if (!selectedSecretId) {
+      setSelectedSecretError('Select a secret to attach.');
+      return;
+    }
+    if (!targetId) {
+      toast.error('Missing target ID.');
+      return;
+    }
+    const target =
+      targetCase === 'mcpId'
+        ? ({ case: 'mcpId', value: targetId } as const)
+        : ({ case: 'hookId', value: targetId } as const);
+
+    createAttachmentMutation.mutate({ imagePullSecretId: selectedSecretId, target });
+  };
+
+  const handleDetach = (attachment: ImagePullSecretAttachment) => {
+    const attachmentId = attachment.meta?.id;
+    if (!attachmentId) {
+      toast.error('Missing attachment ID.');
+      return;
+    }
+    deleteAttachmentMutation.mutate(attachmentId);
+  };
+
+  const renderAttachmentLabel = (attachment: ImagePullSecretAttachment, map: Map<string, ImagePullSecret>) => {
+    const secret = map.get(attachment.imagePullSecretId);
+    const registry = secret?.registry || 'Registry';
+    const username = secret?.username || '';
+    const description = secret?.description || 'Image pull secret';
+    return (
+      <div>
+        <div className="text-sm text-foreground">
+          {registry}
+          {username ? ` (${username})` : ''}
+        </div>
+        <div className="text-xs text-muted-foreground">{description}</div>
+      </div>
+    );
+  };
+
+  const noSecretsAvailable = !imagePullSecretsQuery.isPending && secrets.length === 0;
+  const allSecretsAttached = !imagePullSecretsQuery.isPending && secrets.length > 0 && availableSecrets.length === 0;
+  const attachDisabled =
+    createAttachmentMutation.isPending || imagePullSecretsQuery.isPending || noSecretsAvailable || allSecretsAttached;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="nested-image-pull-secrets-dialog">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="nested-image-pull-secrets-select">Image Pull Secret</Label>
+            <Select
+              value={selectedSecretId}
+              onValueChange={(value) => {
+                setSelectedSecretId(value);
+                if (selectedSecretError) setSelectedSecretError('');
+              }}
+            >
+            <SelectTrigger id="nested-image-pull-secrets-select" data-testid="nested-image-pull-secrets-select">
+              <SelectValue placeholder="Select secret" />
+            </SelectTrigger>
+            <SelectContent>
+                {availableSecrets.map((secret) => {
+                  const secretId = secret.meta?.id;
+                  if (!secretId) return null;
+                  return (
+                    <SelectItem key={secretId} value={secretId}>
+                      {secret.registry} ({secret.username})
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+            {imagePullSecretsQuery.isPending ? (
+              <div className="text-xs text-muted-foreground">Loading image pull secrets...</div>
+            ) : null}
+            {imagePullSecretsQuery.isError ? (
+              <div className="text-xs text-muted-foreground">Failed to load image pull secrets.</div>
+            ) : null}
+            {noSecretsAvailable ? (
+              <div className="text-xs text-muted-foreground">No image pull secrets available.</div>
+            ) : null}
+            {allSecretsAttached ? <div className="text-xs text-muted-foreground">All secrets attached.</div> : null}
+            {selectedSecretError ? <p className="text-sm text-destructive">{selectedSecretError}</p> : null}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleAttach}
+              disabled={attachDisabled}
+              data-testid="nested-image-pull-secrets-attach"
+            >
+              {createAttachmentMutation.isPending ? 'Attaching...' : 'Attach secret'}
+            </Button>
+          </div>
+          <div className="space-y-2">
+            <div className="text-sm font-medium text-foreground">Attached secrets</div>
+            {attachmentsQuery.isPending ? (
+              <div className="text-xs text-muted-foreground">Loading image pull secrets...</div>
+            ) : null}
+            {attachmentsQuery.isError ? (
+              <div className="text-xs text-muted-foreground">Failed to load image pull secrets.</div>
+            ) : null}
+            {attachments.length === 0 && !attachmentsQuery.isPending ? (
+              <div className="text-xs text-muted-foreground">No image pull secrets attached.</div>
+            ) : null}
+            {attachments.length > 0 ? (
+              <div className="divide-y divide-border rounded-md border border-border">
+                {attachments.map((attachment) => (
+                  <div
+                    key={attachment.meta?.id ?? attachment.imagePullSecretId}
+                    className="flex items-center justify-between px-3 py-2"
+                    data-testid="nested-image-pull-secret-row"
+                  >
+                    {renderAttachmentLabel(attachment, secretMap)}
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => handleDetach(attachment)}
+                      disabled={deleteAttachmentMutation.isPending}
+                      data-testid="nested-image-pull-secret-detach"
+                    >
+                      Detach
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" size="sm">
+              Close
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/test/e2e/agent-image-pull-secrets.spec.ts
+++ b/test/e2e/agent-image-pull-secrets.spec.ts
@@ -92,19 +92,19 @@ test('manages MCP image pull secrets dialog', async ({ page }) => {
 
   const dialog = page.getByTestId('nested-image-pull-secrets-dialog');
   await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-empty');
+  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-empty', { element: dialog });
 
   const secretLabel = `${registry} (${username})`;
   await attachSecret(page, secretLabel);
 
   const attachedRow = dialog.getByTestId('nested-image-pull-secret-row').filter({ hasText: registry });
   await expect(attachedRow).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-attached');
+  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-attached', { element: dialog });
 
   await attachedRow.getByTestId('nested-image-pull-secret-detach').click();
   await expect(attachedRow).toHaveCount(0, { timeout: 15000 });
   await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-detached');
+  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-detached', { element: dialog });
 });
 
 test('manages Hook image pull secrets dialog', async ({ page }) => {
@@ -130,17 +130,17 @@ test('manages Hook image pull secrets dialog', async ({ page }) => {
 
   const dialog = page.getByTestId('nested-image-pull-secrets-dialog');
   await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-hook-image-pull-secrets-empty');
+  await argosScreenshot(page, 'agent-hook-image-pull-secrets-empty', { element: dialog });
 
   const secretLabel = `${registry} (${username})`;
   await attachSecret(page, secretLabel);
 
   const attachedRow = dialog.getByTestId('nested-image-pull-secret-row').filter({ hasText: registry });
   await expect(attachedRow).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-hook-image-pull-secrets-attached');
+  await argosScreenshot(page, 'agent-hook-image-pull-secrets-attached', { element: dialog });
 
   await attachedRow.getByTestId('nested-image-pull-secret-detach').click();
   await expect(attachedRow).toHaveCount(0, { timeout: 15000 });
   await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-hook-image-pull-secrets-detached');
+  await argosScreenshot(page, 'agent-hook-image-pull-secrets-detached', { element: dialog });
 });

--- a/test/e2e/agent-image-pull-secrets.spec.ts
+++ b/test/e2e/agent-image-pull-secrets.spec.ts
@@ -92,19 +92,19 @@ test('manages MCP image pull secrets dialog', async ({ page }) => {
 
   const dialog = page.getByTestId('nested-image-pull-secrets-dialog');
   await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-empty', { element: dialog });
+  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-empty', { fullPage: false });
 
   const secretLabel = `${registry} (${username})`;
   await attachSecret(page, secretLabel);
 
   const attachedRow = dialog.getByTestId('nested-image-pull-secret-row').filter({ hasText: registry });
   await expect(attachedRow).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-attached', { element: dialog });
+  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-attached', { fullPage: false });
 
   await attachedRow.getByTestId('nested-image-pull-secret-detach').click();
   await expect(attachedRow).toHaveCount(0, { timeout: 15000 });
   await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-detached', { element: dialog });
+  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-detached', { fullPage: false });
 });
 
 test('manages Hook image pull secrets dialog', async ({ page }) => {
@@ -130,17 +130,17 @@ test('manages Hook image pull secrets dialog', async ({ page }) => {
 
   const dialog = page.getByTestId('nested-image-pull-secrets-dialog');
   await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-hook-image-pull-secrets-empty', { element: dialog });
+  await argosScreenshot(page, 'agent-hook-image-pull-secrets-empty', { fullPage: false });
 
   const secretLabel = `${registry} (${username})`;
   await attachSecret(page, secretLabel);
 
   const attachedRow = dialog.getByTestId('nested-image-pull-secret-row').filter({ hasText: registry });
   await expect(attachedRow).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-hook-image-pull-secrets-attached', { element: dialog });
+  await argosScreenshot(page, 'agent-hook-image-pull-secrets-attached', { fullPage: false });
 
   await attachedRow.getByTestId('nested-image-pull-secret-detach').click();
   await expect(attachedRow).toHaveCount(0, { timeout: 15000 });
   await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'agent-hook-image-pull-secrets-detached', { element: dialog });
+  await argosScreenshot(page, 'agent-hook-image-pull-secrets-detached', { fullPage: false });
 });

--- a/test/e2e/agent-image-pull-secrets.spec.ts
+++ b/test/e2e/agent-image-pull-secrets.spec.ts
@@ -11,6 +11,7 @@ import {
 } from './console-api';
 
 const buildName = (prefix: string, now: number) => `${prefix}-${now}`;
+const buildMcpName = (prefix: string, now: number) => buildName(prefix, now).replace(/-/g, '_');
 
 async function prepareAgentFixture(page: Page, suffix: string) {
   const now = Date.now();
@@ -70,7 +71,7 @@ async function attachSecret(page: Page, secretLabel: string) {
 
 test('manages MCP image pull secrets dialog', async ({ page }) => {
   const { organizationId, agentId, registry, username, now } = await prepareAgentFixture(page, 'mcp');
-  const mcpName = buildName('e2e-mcp', now);
+  const mcpName = buildMcpName('e2e-mcp', now);
   await createMcp(page, {
     agentId,
     name: mcpName,

--- a/test/e2e/agent-image-pull-secrets.spec.ts
+++ b/test/e2e/agent-image-pull-secrets.spec.ts
@@ -1,0 +1,145 @@
+import { argosScreenshot } from '@argos-ci/playwright';
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+import {
+  createAgent,
+  createHook,
+  createImagePullSecret,
+  createMcp,
+  createOrganization,
+  setSelectedOrganization,
+} from './console-api';
+
+const buildName = (prefix: string, now: number) => `${prefix}-${now}`;
+
+async function prepareAgentFixture(page: Page, suffix: string) {
+  const now = Date.now();
+  const organizationId = await createOrganization(page, buildName(`e2e-org-${suffix}`, now));
+  await setSelectedOrganization(page, organizationId);
+
+  const agentName = buildName(`e2e-agent-${suffix}`, now);
+  const agentId = await createAgent(page, {
+    organizationId,
+    name: agentName,
+    role: 'assistant',
+    image: 'ghcr.io/agyn/agent:latest',
+    initImage: 'ghcr.io/agyn/agent-init:latest',
+  });
+
+  const registry = `ghcr.io/e2e/${suffix}`;
+  const username = buildName('e2e-user', now);
+  await createImagePullSecret(page, {
+    organizationId,
+    registry,
+    username,
+    value: buildName('e2e-token', now),
+    description: `E2E image pull secret for ${suffix}`,
+  });
+
+  return {
+    organizationId,
+    agentId,
+    registry,
+    username,
+    now,
+  };
+}
+
+async function openImagePullSecretsDialog(opts: {
+  page: Page;
+  rowTestId: string;
+  rowLabel: string;
+  manageTestId: string;
+  menuTestId: string;
+  menuItemTestId: string;
+}) {
+  const row = opts.page.getByTestId(opts.rowTestId).filter({ hasText: opts.rowLabel });
+  await expect(row).toBeVisible({ timeout: 15000 });
+  await row.getByTestId(opts.manageTestId).click();
+  await expect(opts.page.getByTestId(opts.menuTestId)).toBeVisible({ timeout: 15000 });
+  await opts.page.getByTestId(opts.menuItemTestId).click();
+  await expect(opts.page.getByTestId('nested-image-pull-secrets-dialog')).toBeVisible({ timeout: 15000 });
+}
+
+async function attachSecret(page: Page, secretLabel: string) {
+  await expect(page.getByTestId('nested-image-pull-secrets-attach')).toBeEnabled({ timeout: 15000 });
+  await page.getByTestId('nested-image-pull-secrets-select').click();
+  await page.getByRole('option', { name: secretLabel }).click();
+  await page.getByTestId('nested-image-pull-secrets-attach').click();
+}
+
+test('manages MCP image pull secrets dialog', async ({ page }) => {
+  const { organizationId, agentId, registry, username, now } = await prepareAgentFixture(page, 'mcp');
+  const mcpName = buildName('e2e-mcp', now);
+  await createMcp(page, {
+    agentId,
+    name: mcpName,
+    image: 'ghcr.io/agyn/mcp:latest',
+    command: 'python -m mcp_server',
+    description: 'E2E MCP',
+  });
+
+  await page.goto(`/organizations/${organizationId}/agents/${agentId}`);
+  await openImagePullSecretsDialog({
+    page,
+    rowTestId: 'agent-mcp-row',
+    rowLabel: mcpName,
+    manageTestId: 'agent-mcp-manage',
+    menuTestId: 'agent-mcp-manage-menu',
+    menuItemTestId: 'agent-mcp-image-pull-secrets',
+  });
+
+  const dialog = page.getByTestId('nested-image-pull-secrets-dialog');
+  await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-empty');
+
+  const secretLabel = `${registry} (${username})`;
+  await attachSecret(page, secretLabel);
+
+  const attachedRow = dialog.getByTestId('nested-image-pull-secret-row').filter({ hasText: registry });
+  await expect(attachedRow).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-attached');
+
+  await attachedRow.getByTestId('nested-image-pull-secret-detach').click();
+  await expect(attachedRow).toHaveCount(0, { timeout: 15000 });
+  await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'agent-mcp-image-pull-secrets-detached');
+});
+
+test('manages Hook image pull secrets dialog', async ({ page }) => {
+  const { organizationId, agentId, registry, username, now } = await prepareAgentFixture(page, 'hook');
+  const hookEvent = buildName('e2e-hook-event', now);
+  await createHook(page, {
+    agentId,
+    event: hookEvent,
+    functionName: 'handleHook',
+    image: 'ghcr.io/agyn/hook:latest',
+    description: 'E2E hook',
+  });
+
+  await page.goto(`/organizations/${organizationId}/agents/${agentId}`);
+  await openImagePullSecretsDialog({
+    page,
+    rowTestId: 'agent-hook-row',
+    rowLabel: hookEvent,
+    manageTestId: 'agent-hook-manage',
+    menuTestId: 'agent-hook-manage-menu',
+    menuItemTestId: 'agent-hook-image-pull-secrets',
+  });
+
+  const dialog = page.getByTestId('nested-image-pull-secrets-dialog');
+  await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'agent-hook-image-pull-secrets-empty');
+
+  const secretLabel = `${registry} (${username})`;
+  await attachSecret(page, secretLabel);
+
+  const attachedRow = dialog.getByTestId('nested-image-pull-secret-row').filter({ hasText: registry });
+  await expect(attachedRow).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'agent-hook-image-pull-secrets-attached');
+
+  await attachedRow.getByTestId('nested-image-pull-secret-detach').click();
+  await expect(attachedRow).toHaveCount(0, { timeout: 15000 });
+  await expect(dialog.getByText('No image pull secrets attached.')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'agent-hook-image-pull-secrets-detached');
+});

--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -4,6 +4,7 @@ import { readOidcSession } from './oidc-helpers';
 const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
 const ORGS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.OrganizationsGateway';
 const SECRETS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.SecretsGateway';
+const AGENTS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.AgentsGateway';
 const RUNNERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.RunnersGateway';
 
 const CONNECT_HEADERS = {
@@ -96,8 +97,36 @@ type SecretWire = {
   secretProviderId?: string;
 };
 
+type AgentWire = {
+  meta?: { id?: string };
+  name?: string;
+  role?: string;
+  model?: string;
+  description?: string;
+  configuration?: string;
+  image?: string;
+  initImage?: string;
+  organizationId?: string;
+};
+
+type McpWire = {
+  meta?: { id?: string };
+  name?: string;
+  agentId?: string;
+};
+
+type HookWire = {
+  meta?: { id?: string };
+  event?: string;
+  agentId?: string;
+};
+
 type CreateSecretResponseWire = {
   secret?: { meta?: { id?: string } };
+};
+
+type CreateImagePullSecretResponseWire = {
+  imagePullSecret?: { meta?: { id?: string } };
 };
 
 type ListSecretsResponseWire = {
@@ -111,6 +140,18 @@ type CreateDeviceResponseWire = {
 
 type ListDevicesResponseWire = {
   devices?: DeviceWire[];
+};
+
+type CreateAgentResponseWire = {
+  agent?: AgentWire;
+};
+
+type CreateMcpResponseWire = {
+  mcp?: McpWire;
+};
+
+type CreateHookResponseWire = {
+  hook?: HookWire;
 };
 
 type ListRunnersResponseWire = {
@@ -476,6 +517,101 @@ export async function createSecret(
     throw new Error('CreateSecret response missing secret id.');
   }
   return secretId;
+}
+
+export async function createImagePullSecret(
+  page: Page,
+  opts: { organizationId: string; registry: string; username: string; value: string; description?: string },
+): Promise<string> {
+  const response = await postConnect<CreateImagePullSecretResponseWire>(
+    page,
+    SECRETS_GATEWAY_PATH,
+    'CreateImagePullSecret',
+    {
+      description: opts.description ?? `E2E image pull secret for ${opts.registry}`,
+      registry: opts.registry,
+      username: opts.username,
+      source: { case: 'value', value: opts.value },
+      organizationId: opts.organizationId,
+    },
+  );
+  const secretId = response.imagePullSecret?.meta?.id;
+  if (!secretId) {
+    throw new Error('CreateImagePullSecret response missing image pull secret id.');
+  }
+  return secretId;
+}
+
+export async function createAgent(
+  page: Page,
+  opts: {
+    organizationId: string;
+    name: string;
+    role?: string;
+    model?: string;
+    description?: string;
+    configuration?: string;
+    image?: string;
+    initImage?: string;
+  },
+): Promise<string> {
+  const response = await postConnect<CreateAgentResponseWire>(page, AGENTS_GATEWAY_PATH, 'CreateAgent', {
+    name: opts.name,
+    role: opts.role ?? 'assistant',
+    model: opts.model ?? '',
+    description: opts.description ?? '',
+    configuration: opts.configuration ?? '',
+    image: opts.image ?? '',
+    initImage: opts.initImage ?? '',
+    organizationId: opts.organizationId,
+  });
+  const agentId = response.agent?.meta?.id;
+  if (!agentId) {
+    throw new Error('CreateAgent response missing agent id.');
+  }
+  return agentId;
+}
+
+export async function createMcp(
+  page: Page,
+  opts: { agentId: string; name: string; image: string; command: string; description?: string },
+): Promise<string> {
+  const response = await postConnect<CreateMcpResponseWire>(page, AGENTS_GATEWAY_PATH, 'CreateMcp', {
+    agentId: opts.agentId,
+    name: opts.name,
+    image: opts.image,
+    command: opts.command,
+    description: opts.description ?? '',
+  });
+  const mcpId = response.mcp?.meta?.id;
+  if (!mcpId) {
+    throw new Error('CreateMcp response missing mcp id.');
+  }
+  return mcpId;
+}
+
+export async function createHook(
+  page: Page,
+  opts: {
+    agentId: string;
+    event: string;
+    functionName: string;
+    image: string;
+    description?: string;
+  },
+): Promise<string> {
+  const response = await postConnect<CreateHookResponseWire>(page, AGENTS_GATEWAY_PATH, 'CreateHook', {
+    agentId: opts.agentId,
+    event: opts.event,
+    function: opts.functionName,
+    image: opts.image,
+    description: opts.description ?? '',
+  });
+  const hookId = response.hook?.meta?.id;
+  if (!hookId) {
+    throw new Error('CreateHook response missing hook id.');
+  }
+  return hookId;
 }
 
 export async function deleteSecret(page: Page, secretId: string): Promise<void> {

--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -5,6 +5,7 @@ const USERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.UsersGateway';
 const ORGS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.OrganizationsGateway';
 const SECRETS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.SecretsGateway';
 const AGENTS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.AgentsGateway';
+const LLM_GATEWAY_PATH = '/api/agynio.api.gateway.v1.LLMGateway';
 const RUNNERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.RunnersGateway';
 
 const CONNECT_HEADERS = {
@@ -121,6 +122,13 @@ type HookWire = {
   agentId?: string;
 };
 
+type ModelWire = {
+  meta?: { id?: string };
+  name?: string;
+  llmProviderId?: string;
+  remoteName?: string;
+};
+
 type CreateSecretResponseWire = {
   secret?: { meta?: { id?: string } };
 };
@@ -140,6 +148,10 @@ type CreateDeviceResponseWire = {
 
 type ListDevicesResponseWire = {
   devices?: DeviceWire[];
+};
+
+type ListModelsResponseWire = {
+  models?: ModelWire[];
 };
 
 type CreateAgentResponseWire = {
@@ -501,6 +513,19 @@ export async function listSecrets(
   return response.secrets ?? [];
 }
 
+export async function listModels(
+  page: Page,
+  opts: { organizationId: string; llmProviderId?: string },
+): Promise<ModelWire[]> {
+  const response = await postConnect<ListModelsResponseWire>(page, LLM_GATEWAY_PATH, 'ListModels', {
+    organizationId: opts.organizationId,
+    llmProviderId: opts.llmProviderId ?? '',
+    pageSize: 200,
+    pageToken: '',
+  });
+  return response.models ?? [];
+}
+
 export async function createSecret(
   page: Page,
   opts: { providerId: string; name: string; value: string; organizationId: string },
@@ -531,7 +556,7 @@ export async function createImagePullSecret(
       description: opts.description ?? `E2E image pull secret for ${opts.registry}`,
       registry: opts.registry,
       username: opts.username,
-      source: { case: 'value', value: opts.value },
+      value: opts.value,
       organizationId: opts.organizationId,
     },
   );
@@ -555,10 +580,18 @@ export async function createAgent(
     initImage?: string;
   },
 ): Promise<string> {
+  let modelId = opts.model?.trim() ?? '';
+  if (!modelId) {
+    const models = await listModels(page, { organizationId: opts.organizationId });
+    modelId = models.find((model) => model.meta?.id)?.meta?.id ?? '';
+    if (!modelId) {
+      throw new Error('ListModels response missing model id for agent creation.');
+    }
+  }
   const response = await postConnect<CreateAgentResponseWire>(page, AGENTS_GATEWAY_PATH, 'CreateAgent', {
     name: opts.name,
     role: opts.role ?? 'assistant',
-    model: opts.model ?? '',
+    model: modelId,
     description: opts.description ?? '',
     configuration: opts.configuration ?? '',
     image: opts.image ?? '',

--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -124,9 +124,18 @@ type HookWire = {
 
 type ModelWire = {
   meta?: { id?: string };
+  id?: string;
   name?: string;
   llmProviderId?: string;
   remoteName?: string;
+};
+
+type LlmProviderWire = {
+  meta?: { id?: string };
+  id?: string;
+  endpoint?: string;
+  authMethod?: string | number;
+  organizationId?: string;
 };
 
 type CreateSecretResponseWire = {
@@ -153,6 +162,20 @@ type ListDevicesResponseWire = {
 type ListModelsResponseWire = {
   models?: ModelWire[];
 };
+
+type ListLlmProvidersResponseWire = {
+  providers?: LlmProviderWire[];
+};
+
+type CreateLlmProviderResponseWire = {
+  provider?: LlmProviderWire;
+};
+
+type CreateModelResponseWire = {
+  model?: ModelWire;
+};
+
+type EntityWithId = { meta?: { id?: string }; id?: string };
 
 type CreateAgentResponseWire = {
   agent?: AgentWire;
@@ -190,6 +213,15 @@ function resolveBaseUrl(): string {
 
 function buildRpcUrl(servicePath: string, method: string): string {
   return new URL(`${servicePath}/${method}`, resolveBaseUrl()).toString();
+}
+
+function findEntityId(entities: EntityWithId[] | undefined): string {
+  if (!entities) return '';
+  for (const entity of entities) {
+    const id = entity.meta?.id ?? entity.id ?? '';
+    if (id) return id;
+  }
+  return '';
 }
 
 const CLUSTER_ROLE_ADMIN = 1;
@@ -513,6 +545,18 @@ export async function listSecrets(
   return response.secrets ?? [];
 }
 
+export async function listLlmProviders(
+  page: Page,
+  opts: { organizationId: string },
+): Promise<LlmProviderWire[]> {
+  const response = await postConnect<ListLlmProvidersResponseWire>(page, LLM_GATEWAY_PATH, 'ListLLMProviders', {
+    organizationId: opts.organizationId,
+    pageSize: 200,
+    pageToken: '',
+  });
+  return response.providers ?? [];
+}
+
 export async function listModels(
   page: Page,
   opts: { organizationId: string; llmProviderId?: string },
@@ -524,6 +568,68 @@ export async function listModels(
     pageToken: '',
   });
   return response.models ?? [];
+}
+
+async function createLlmProvider(
+  page: Page,
+  opts: { organizationId: string; endpoint: string; token: string; authMethod?: string | number },
+): Promise<string> {
+  const response = await postConnect<CreateLlmProviderResponseWire>(page, LLM_GATEWAY_PATH, 'CreateLLMProvider', {
+    endpoint: opts.endpoint,
+    authMethod: opts.authMethod ?? 'AUTH_METHOD_BEARER',
+    token: opts.token,
+    organizationId: opts.organizationId,
+  });
+  const providerId = response.provider?.meta?.id ?? response.provider?.id ?? '';
+  if (!providerId) {
+    throw new Error('CreateLLMProvider response missing provider id.');
+  }
+  return providerId;
+}
+
+async function createModel(
+  page: Page,
+  opts: { organizationId: string; llmProviderId: string; name: string; remoteName: string },
+): Promise<string> {
+  const response = await postConnect<CreateModelResponseWire>(page, LLM_GATEWAY_PATH, 'CreateModel', {
+    name: opts.name,
+    llmProviderId: opts.llmProviderId,
+    remoteName: opts.remoteName,
+    organizationId: opts.organizationId,
+  });
+  const modelId = response.model?.meta?.id ?? response.model?.id ?? '';
+  if (!modelId) {
+    throw new Error('CreateModel response missing model id.');
+  }
+  return modelId;
+}
+
+async function ensureLlmProviderId(page: Page, organizationId: string): Promise<string> {
+  const providers = await listLlmProviders(page, { organizationId });
+  const providerId = findEntityId(providers);
+  if (providerId) return providerId;
+
+  const now = Date.now();
+  return createLlmProvider(page, {
+    organizationId,
+    endpoint: `https://llm.e2e.agyn.dev/${now}`,
+    token: `e2e-token-${now}`,
+  });
+}
+
+async function ensureModelId(page: Page, organizationId: string): Promise<string> {
+  const models = await listModels(page, { organizationId });
+  const modelId = findEntityId(models);
+  if (modelId) return modelId;
+
+  const providerId = await ensureLlmProviderId(page, organizationId);
+  const now = Date.now();
+  return createModel(page, {
+    organizationId,
+    llmProviderId: providerId,
+    name: `E2E Model ${now}`,
+    remoteName: 'gpt-4o-mini',
+  });
 }
 
 export async function createSecret(
@@ -582,11 +688,7 @@ export async function createAgent(
 ): Promise<string> {
   let modelId = opts.model?.trim() ?? '';
   if (!modelId) {
-    const models = await listModels(page, { organizationId: opts.organizationId });
-    modelId = models.find((model) => model.meta?.id)?.meta?.id ?? '';
-    if (!modelId) {
-      throw new Error('ListModels response missing model id for agent creation.');
-    }
+    modelId = await ensureModelId(page, opts.organizationId);
   }
   const response = await postConnect<CreateAgentResponseWire>(page, AGENTS_GATEWAY_PATH, 'CreateAgent', {
     name: opts.name,

--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -281,6 +281,14 @@ function isNotFoundError(error: unknown): boolean {
   return error.message.includes('status 404');
 }
 
+function isAlreadyClusterAdminError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.includes('tuple to be written already existed') ||
+    error.message.includes('tuple to be written already exists')
+  );
+}
+
 export async function getMe(page: Page): Promise<GetMeResponseWire> {
   const response = await postConnect<GetMeResponseWire>(page, USERS_GATEWAY_PATH, 'GetMe', {});
   if (!response.user?.meta?.id) {
@@ -298,10 +306,16 @@ export async function ensureClusterAdmin(page: Page): Promise<void> {
   if (!identityId) {
     throw new Error('GetMe response missing identity id for cluster role update.');
   }
-  await postConnectAsClusterAdmin<UpdateUserResponseWire>(page, USERS_GATEWAY_PATH, 'UpdateUser', {
-    identityId,
-    clusterRole: 'CLUSTER_ROLE_ADMIN',
-  });
+  try {
+    await postConnectAsClusterAdmin<UpdateUserResponseWire>(page, USERS_GATEWAY_PATH, 'UpdateUser', {
+      identityId,
+      clusterRole: 'CLUSTER_ROLE_ADMIN',
+    });
+  } catch (error) {
+    if (!isAlreadyClusterAdminError(error)) {
+      throw error;
+    }
+  }
   const start = Date.now();
   while (Date.now() - start < 10000) {
     const updated = await getMe(page);

--- a/test/e2e/devices.spec.ts
+++ b/test/e2e/devices.spec.ts
@@ -40,7 +40,8 @@ test('creates a device and shows enrollment JWT', async ({ page }) => {
   await page.getByTestId('devices-create').click();
   await expect(page.getByTestId('devices-create-dialog')).toBeVisible({ timeout: 15000 });
 
-  await page.getByTestId('devices-name').fill(deviceName);
+  const createDialog = page.getByTestId('devices-create-dialog');
+  await createDialog.getByTestId('devices-name').fill(deviceName);
   await page.getByTestId('devices-submit').click();
 
   await expect(page.getByTestId('devices-jwt-value')).toBeVisible({ timeout: 15000 });

--- a/test/e2e/mock-server.mjs
+++ b/test/e2e/mock-server.mjs
@@ -11,7 +11,13 @@ const organizations = new Map();
 const memberships = new Map();
 const secretProviders = new Map();
 const secrets = new Map();
+const imagePullSecrets = new Map();
 const runners = new Map();
+const devices = new Map();
+const agents = new Map();
+const mcps = new Map();
+const hooks = new Map();
+const imagePullSecretAttachments = new Map();
 
 const defaultUser = {
   id: defaultUserId,
@@ -188,6 +194,80 @@ function mapSecret(secret) {
   };
 }
 
+function mapEntityMeta(entity) {
+  return {
+    id: entity.id,
+    createdAt: entity.createdAt,
+  };
+}
+
+function mapDevice(device) {
+  return {
+    meta: mapEntityMeta(device),
+    userIdentityId: device.userIdentityId,
+    name: device.name,
+    openzitiIdentityId: device.openzitiIdentityId,
+    status: device.status,
+  };
+}
+
+function mapAgent(agent) {
+  return {
+    meta: mapEntityMeta(agent),
+    name: agent.name,
+    role: agent.role,
+    model: agent.model,
+    description: agent.description,
+    configuration: agent.configuration,
+    image: agent.image,
+    initImage: agent.initImage,
+    resources: agent.resources,
+    organizationId: agent.organizationId,
+  };
+}
+
+function mapMcp(mcp) {
+  return {
+    meta: mapEntityMeta(mcp),
+    agentId: mcp.agentId,
+    image: mcp.image,
+    command: mcp.command,
+    description: mcp.description,
+    name: mcp.name,
+    resources: mcp.resources,
+  };
+}
+
+function mapHook(hook) {
+  return {
+    meta: mapEntityMeta(hook),
+    agentId: hook.agentId,
+    event: hook.event,
+    function: hook.functionName,
+    image: hook.image,
+    description: hook.description,
+    resources: hook.resources,
+  };
+}
+
+function mapImagePullSecret(secret) {
+  return {
+    meta: mapEntityMeta(secret),
+    description: secret.description,
+    registry: secret.registry,
+    username: secret.username,
+    organizationId: secret.organizationId,
+  };
+}
+
+function mapImagePullSecretAttachment(attachment) {
+  return {
+    meta: mapEntityMeta(attachment),
+    imagePullSecretId: attachment.imagePullSecretId,
+    target: attachment.target,
+  };
+}
+
 function handleUsersGateway(method, body, res) {
   switch (method) {
     case 'GetMe': {
@@ -247,6 +327,29 @@ function handleUsersGateway(method, body, res) {
     }
     case 'DeleteUser': {
       if (body.identityId) users.delete(body.identityId);
+      return sendJson(res, 200, {});
+    }
+    case 'CreateDevice': {
+      const id = randomUUID();
+      const device = {
+        id,
+        userIdentityId: defaultUserId,
+        name: body.name ?? `device-${id}`,
+        openzitiIdentityId: `openziti-${id}`,
+        status: 'DEVICE_STATUS_PENDING',
+        createdAt: new Date().toISOString(),
+      };
+      devices.set(id, device);
+      return sendJson(res, 200, { device: mapDevice(device), enrollmentJwt: createJwt({ deviceId: id }) });
+    }
+    case 'ListDevices': {
+      return sendJson(res, 200, {
+        devices: Array.from(devices.values()).map(mapDevice),
+        nextPageToken: '',
+      });
+    }
+    case 'DeleteDevice': {
+      if (body.id) devices.delete(body.id);
       return sendJson(res, 200, {});
     }
     default:
@@ -383,6 +486,44 @@ function handleSecretsGateway(method, body, res) {
       if (body.id) secrets.delete(body.id);
       return sendJson(res, 200, {});
     }
+    case 'CreateImagePullSecret': {
+      const id = randomUUID();
+      const secret = {
+        id,
+        description: body.description ?? '',
+        registry: body.registry ?? '',
+        username: body.username ?? '',
+        organizationId: body.organizationId ?? '',
+        createdAt: new Date().toISOString(),
+      };
+      imagePullSecrets.set(id, secret);
+      return sendJson(res, 200, { imagePullSecret: mapImagePullSecret(secret) });
+    }
+    case 'ListImagePullSecrets': {
+      const result = Array.from(imagePullSecrets.values()).filter(
+        (secret) => secret.organizationId === body.organizationId,
+      );
+      return sendJson(res, 200, { imagePullSecrets: result.map(mapImagePullSecret), nextPageToken: '' });
+    }
+    case 'UpdateImagePullSecret': {
+      const secret = imagePullSecrets.get(body.id);
+      if (!secret) return sendText(res, 404, 'Image pull secret not found');
+      secret.description = body.description ?? secret.description;
+      secret.registry = body.registry ?? secret.registry;
+      secret.username = body.username ?? secret.username;
+      return sendJson(res, 200, { imagePullSecret: mapImagePullSecret(secret) });
+    }
+    case 'DeleteImagePullSecret': {
+      if (body.id) {
+        imagePullSecrets.delete(body.id);
+        for (const [attachmentId, attachment] of imagePullSecretAttachments.entries()) {
+          if (attachment.imagePullSecretId === body.id) {
+            imagePullSecretAttachments.delete(attachmentId);
+          }
+        }
+      }
+      return sendJson(res, 200, {});
+    }
     default:
       return sendText(res, 404, 'Unknown SecretsGateway method');
   }
@@ -421,11 +562,167 @@ function handleRunnersGateway(method, body, res) {
   }
 }
 
-function handleAgentsGateway(method, _body, res) {
-  if (method === 'ListAgents') {
-    return sendJson(res, 200, { agents: [], nextPageToken: '' });
+function handleAgentsGateway(method, body, res) {
+  switch (method) {
+    case 'CreateAgent': {
+      const id = randomUUID();
+      const agent = {
+        id,
+        name: body.name ?? `agent-${id}`,
+        role: body.role ?? '',
+        model: body.model ?? '',
+        description: body.description ?? '',
+        configuration: body.configuration ?? '',
+        image: body.image ?? '',
+        initImage: body.initImage ?? '',
+        resources: body.resources,
+        organizationId: body.organizationId ?? '',
+        createdAt: new Date().toISOString(),
+      };
+      agents.set(id, agent);
+      return sendJson(res, 200, { agent: mapAgent(agent) });
+    }
+    case 'GetAgent': {
+      const agent = agents.get(body.id);
+      if (!agent) return sendText(res, 404, 'Agent not found');
+      return sendJson(res, 200, { agent: mapAgent(agent) });
+    }
+    case 'ListAgents': {
+      const orgId = body.organizationId ?? '';
+      const result = Array.from(agents.values()).filter((agent) => !orgId || agent.organizationId === orgId);
+      return sendJson(res, 200, { agents: result.map(mapAgent), nextPageToken: '' });
+    }
+    case 'DeleteAgent': {
+      if (body.id) {
+        agents.delete(body.id);
+        for (const [mcpId, mcp] of mcps.entries()) {
+          if (mcp.agentId === body.id) mcps.delete(mcpId);
+        }
+        for (const [hookId, hook] of hooks.entries()) {
+          if (hook.agentId === body.id) hooks.delete(hookId);
+        }
+        for (const [attachmentId, attachment] of imagePullSecretAttachments.entries()) {
+          if (attachment.target.case === 'agentId' && attachment.target.value === body.id) {
+            imagePullSecretAttachments.delete(attachmentId);
+          }
+        }
+      }
+      return sendJson(res, 200, {});
+    }
+    case 'CreateMcp': {
+      const id = randomUUID();
+      const mcp = {
+        id,
+        agentId: body.agentId ?? '',
+        image: body.image ?? '',
+        command: body.command ?? '',
+        description: body.description ?? '',
+        name: body.name ?? `mcp-${id}`,
+        resources: body.resources,
+        createdAt: new Date().toISOString(),
+      };
+      mcps.set(id, mcp);
+      return sendJson(res, 200, { mcp: mapMcp(mcp) });
+    }
+    case 'ListMcps': {
+      const agentId = body.agentId ?? '';
+      const result = Array.from(mcps.values()).filter((mcp) => !agentId || mcp.agentId === agentId);
+      return sendJson(res, 200, { mcps: result.map(mapMcp), nextPageToken: '' });
+    }
+    case 'CreateHook': {
+      const id = randomUUID();
+      const hook = {
+        id,
+        agentId: body.agentId ?? '',
+        event: body.event ?? '',
+        functionName: body.function ?? '',
+        image: body.image ?? '',
+        description: body.description ?? '',
+        resources: body.resources,
+        createdAt: new Date().toISOString(),
+      };
+      hooks.set(id, hook);
+      return sendJson(res, 200, { hook: mapHook(hook) });
+    }
+    case 'ListHooks': {
+      const agentId = body.agentId ?? '';
+      const result = Array.from(hooks.values()).filter((hook) => !agentId || hook.agentId === agentId);
+      return sendJson(res, 200, { hooks: result.map(mapHook), nextPageToken: '' });
+    }
+    case 'CreateImagePullSecretAttachment': {
+      const imagePullSecretId = body.imagePullSecretId ?? '';
+      let target = body.target;
+      if (!target?.case || !target?.value) {
+        if (body.agentId) {
+          target = { case: 'agentId', value: body.agentId };
+        } else if (body.mcpId) {
+          target = { case: 'mcpId', value: body.mcpId };
+        } else if (body.hookId) {
+          target = { case: 'hookId', value: body.hookId };
+        }
+      }
+      if (!imagePullSecretId || !target?.case || !target?.value) {
+        return sendText(res, 400, 'Missing image pull secret attachment target');
+      }
+      const alreadyExists = Array.from(imagePullSecretAttachments.values()).some(
+        (attachment) =>
+          attachment.imagePullSecretId === imagePullSecretId &&
+          attachment.target.case === target.case &&
+          attachment.target.value === target.value,
+      );
+      if (alreadyExists) {
+        return sendText(res, 409, 'Image pull secret attachment already exists');
+      }
+      const id = randomUUID();
+      const attachment = {
+        id,
+        imagePullSecretId,
+        target: { case: target.case, value: target.value },
+        createdAt: new Date().toISOString(),
+      };
+      imagePullSecretAttachments.set(id, attachment);
+      return sendJson(res, 200, { imagePullSecretAttachment: mapImagePullSecretAttachment(attachment) });
+    }
+    case 'ListImagePullSecretAttachments': {
+      const result = Array.from(imagePullSecretAttachments.values()).filter((attachment) => {
+        if (body.imagePullSecretId && attachment.imagePullSecretId !== body.imagePullSecretId) {
+          return false;
+        }
+        if (body.agentId) {
+          return attachment.target.case === 'agentId' && attachment.target.value === body.agentId;
+        }
+        if (body.mcpId) {
+          return attachment.target.case === 'mcpId' && attachment.target.value === body.mcpId;
+        }
+        if (body.hookId) {
+          return attachment.target.case === 'hookId' && attachment.target.value === body.hookId;
+        }
+        return true;
+      });
+      return sendJson(res, 200, { imagePullSecretAttachments: result.map(mapImagePullSecretAttachment), nextPageToken: '' });
+    }
+    case 'DeleteImagePullSecretAttachment': {
+      if (body.id) imagePullSecretAttachments.delete(body.id);
+      return sendJson(res, 200, {});
+    }
+    case 'ListSkills': {
+      return sendJson(res, 200, { skills: [], nextPageToken: '' });
+    }
+    case 'ListEnvs': {
+      return sendJson(res, 200, { envs: [], nextPageToken: '' });
+    }
+    case 'ListInitScripts': {
+      return sendJson(res, 200, { initScripts: [], nextPageToken: '' });
+    }
+    case 'ListVolumeAttachments': {
+      return sendJson(res, 200, { volumeAttachments: [], nextPageToken: '' });
+    }
+    case 'ListVolumes': {
+      return sendJson(res, 200, { volumes: [], nextPageToken: '' });
+    }
+    default:
+      return sendText(res, 404, 'Unknown AgentsGateway method');
   }
-  return sendText(res, 404, 'Unknown AgentsGateway method');
 }
 
 function handleAppsGateway(method, _body, res) {
@@ -433,6 +730,13 @@ function handleAppsGateway(method, _body, res) {
     return sendJson(res, 200, { installations: [], nextPageToken: '' });
   }
   return sendText(res, 404, 'Unknown AppsGateway method');
+}
+
+function handleLlmGateway(method, _body, res) {
+  if (method === 'ListModels') {
+    return sendJson(res, 200, { models: [], nextPageToken: '' });
+  }
+  return sendText(res, 404, 'Unknown LLMGateway method');
 }
 
 const server = http.createServer(async (req, res) => {
@@ -531,6 +835,9 @@ const server = http.createServer(async (req, res) => {
     }
     if (service === 'agynio.api.gateway.v1.AgentsGateway') {
       return handleAgentsGateway(method, body, res);
+    }
+    if (service === 'agynio.api.gateway.v1.LLMGateway') {
+      return handleLlmGateway(method, body, res);
     }
     if (service === 'agynio.api.gateway.v1.AppsGateway') {
       return handleAppsGateway(method, body, res);

--- a/test/e2e/mock-server.mjs
+++ b/test/e2e/mock-server.mjs
@@ -17,6 +17,7 @@ const devices = new Map();
 const agents = new Map();
 const mcps = new Map();
 const hooks = new Map();
+const llmProviders = new Map();
 const models = new Map();
 const imagePullSecretAttachments = new Map();
 
@@ -44,11 +45,23 @@ const defaultRunner = {
 
 runners.set(defaultRunner.id, defaultRunner);
 
+const defaultLlmProvider = {
+  id: 'llm-provider-e2e',
+  endpoint: 'https://llm.e2e.agyn.dev',
+  authMethod: 'AUTH_METHOD_BEARER',
+  organizationId: '',
+  token: 'e2e-token',
+  createdAt: new Date().toISOString(),
+};
+
+llmProviders.set(defaultLlmProvider.id, defaultLlmProvider);
+
 const defaultModel = {
   id: 'model-e2e',
   name: 'E2E Model',
   llmProviderId: 'llm-provider-e2e',
   remoteName: 'gpt-4o-mini',
+  organizationId: defaultLlmProvider.organizationId,
   createdAt: new Date().toISOString(),
 };
 
@@ -267,6 +280,15 @@ function mapModel(model) {
     name: model.name,
     llmProviderId: model.llmProviderId,
     remoteName: model.remoteName,
+  };
+}
+
+function mapLlmProvider(provider) {
+  return {
+    meta: mapEntityMeta(provider),
+    endpoint: provider.endpoint,
+    authMethod: provider.authMethod,
+    organizationId: provider.organizationId,
   };
 }
 
@@ -753,14 +775,51 @@ function handleAppsGateway(method, _body, res) {
 }
 
 function handleLlmGateway(method, body, res) {
-  if (method === 'ListModels') {
-    const providerId = body.llmProviderId ?? '';
-    const result = Array.from(models.values()).filter(
-      (model) => !providerId || model.llmProviderId === providerId,
-    );
-    return sendJson(res, 200, { models: result.map(mapModel), nextPageToken: '' });
+  switch (method) {
+    case 'ListLLMProviders': {
+      const organizationId = body.organizationId ?? '';
+      const result = Array.from(llmProviders.values()).filter(
+        (provider) => !organizationId || provider.organizationId === organizationId,
+      );
+      return sendJson(res, 200, { providers: result.map(mapLlmProvider), nextPageToken: '' });
+    }
+    case 'CreateLLMProvider': {
+      const provider = {
+        id: randomUUID(),
+        endpoint: body.endpoint ?? '',
+        authMethod: body.authMethod ?? 'AUTH_METHOD_BEARER',
+        organizationId: body.organizationId ?? '',
+        token: body.token ?? '',
+        createdAt: new Date().toISOString(),
+      };
+      llmProviders.set(provider.id, provider);
+      return sendJson(res, 200, { provider: mapLlmProvider(provider) });
+    }
+    case 'CreateModel': {
+      const model = {
+        id: randomUUID(),
+        name: body.name ?? '',
+        llmProviderId: body.llmProviderId ?? '',
+        remoteName: body.remoteName ?? '',
+        organizationId: body.organizationId ?? '',
+        createdAt: new Date().toISOString(),
+      };
+      models.set(model.id, model);
+      return sendJson(res, 200, { model: mapModel(model) });
+    }
+    case 'ListModels': {
+      const providerId = body.llmProviderId ?? '';
+      const organizationId = body.organizationId ?? '';
+      const result = Array.from(models.values()).filter((model) => {
+        if (providerId && model.llmProviderId !== providerId) return false;
+        if (organizationId && model.organizationId !== organizationId) return false;
+        return true;
+      });
+      return sendJson(res, 200, { models: result.map(mapModel), nextPageToken: '' });
+    }
+    default:
+      return sendText(res, 404, 'Unknown LLMGateway method');
   }
-  return sendText(res, 404, 'Unknown LLMGateway method');
 }
 
 const server = http.createServer(async (req, res) => {

--- a/test/e2e/mock-server.mjs
+++ b/test/e2e/mock-server.mjs
@@ -17,6 +17,7 @@ const devices = new Map();
 const agents = new Map();
 const mcps = new Map();
 const hooks = new Map();
+const models = new Map();
 const imagePullSecretAttachments = new Map();
 
 const defaultUser = {
@@ -42,6 +43,16 @@ const defaultRunner = {
 };
 
 runners.set(defaultRunner.id, defaultRunner);
+
+const defaultModel = {
+  id: 'model-e2e',
+  name: 'E2E Model',
+  llmProviderId: 'llm-provider-e2e',
+  remoteName: 'gpt-4o-mini',
+  createdAt: new Date().toISOString(),
+};
+
+models.set(defaultModel.id, defaultModel);
 
 function setCors(res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -247,6 +258,15 @@ function mapHook(hook) {
     image: hook.image,
     description: hook.description,
     resources: hook.resources,
+  };
+}
+
+function mapModel(model) {
+  return {
+    meta: mapEntityMeta(model),
+    name: model.name,
+    llmProviderId: model.llmProviderId,
+    remoteName: model.remoteName,
   };
 }
 
@@ -732,9 +752,13 @@ function handleAppsGateway(method, _body, res) {
   return sendText(res, 404, 'Unknown AppsGateway method');
 }
 
-function handleLlmGateway(method, _body, res) {
+function handleLlmGateway(method, body, res) {
   if (method === 'ListModels') {
-    return sendJson(res, 200, { models: [], nextPageToken: '' });
+    const providerId = body.llmProviderId ?? '';
+    const result = Array.from(models.values()).filter(
+      (model) => !providerId || model.llmProviderId === providerId,
+    );
+    return sendJson(res, 200, { models: result.map(mapModel), nextPageToken: '' });
   }
   return sendText(res, 404, 'Unknown LLMGateway method');
 }


### PR DESCRIPTION
## Summary
- add a nested image pull secrets dialog for MCPs and Hooks
- add MCP/Hook manage menu entries and wire organization context

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #47