### PR TITLE
Fix agent nickname and dialog overflow

### DIFF
--- a/src/__tests__/nickname.test.ts
+++ b/src/__tests__/nickname.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { NICKNAME_MAX_LENGTH, getNicknameValidationError } from '@/lib/nickname';
+
+describe('nickname validation', () => {
+  it('accepts empty values', () => {
+    expect(getNicknameValidationError('')).toBe('');
+  });
+
+  it('accepts valid nicknames', () => {
+    const validValues = ['my-agent', 'a', 'a_b-c123'];
+
+    validValues.forEach((value) => {
+      expect(getNicknameValidationError(value)).toBe('');
+    });
+  });
+
+  it('accepts exactly max length', () => {
+    const value = 'a'.repeat(NICKNAME_MAX_LENGTH);
+
+    expect(getNicknameValidationError(value)).toBe('');
+  });
+
+  it('rejects nicknames that are too long', () => {
+    const value = 'a'.repeat(NICKNAME_MAX_LENGTH + 1);
+
+    expect(getNicknameValidationError(value)).toBe('Nickname must be 32 characters or fewer.');
+  });
+
+  it('rejects nicknames with invalid characters', () => {
+    const invalidValues = ['My-Agent', 'bad nickname', '@agent', 'agent.name', 'agent!'];
+
+    invalidValues.forEach((value) => {
+      expect(getNicknameValidationError(value)).toBe(
+        'Nickname can only include lowercase letters, numbers, underscores, and hyphens.',
+      );
+    });
+  });
+});

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -59,7 +59,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
           className,
         )}
         {...props}

--- a/src/lib/nickname.ts
+++ b/src/lib/nickname.ts
@@ -1,0 +1,14 @@
+const NICKNAME_PATTERN = /^[a-z0-9_-]+$/;
+
+export const NICKNAME_MAX_LENGTH = 32;
+
+export function getNicknameValidationError(value: string): string {
+  if (!value) return '';
+  if (value.length > NICKNAME_MAX_LENGTH) {
+    return 'Nickname must be 32 characters or fewer.';
+  }
+  if (!NICKNAME_PATTERN.test(value)) {
+    return 'Nickname can only include lowercase letters, numbers, underscores, and hyphens.';
+  }
+  return '';
+}

--- a/src/pages/AgentCreatePage.tsx
+++ b/src/pages/AgentCreatePage.tsx
@@ -13,6 +13,7 @@ import type { ComputeResources } from '@/gen/agynio/api/agents/v1/agents_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { NO_MODEL } from '@/lib/constants';
 import { GO_DURATION_HELP_TEXT, isValidGoDuration } from '@/lib/duration';
+import { NICKNAME_MAX_LENGTH, getNicknameValidationError } from '@/lib/nickname';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
 import { toast } from 'sonner';
 
@@ -25,6 +26,8 @@ export function AgentCreatePage() {
   const queryClient = useQueryClient();
   const [name, setName] = useState('');
   const [nameError, setNameError] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [nicknameError, setNicknameError] = useState('');
   const [role, setRole] = useState('');
   const [modelId, setModelId] = useState(NO_MODEL);
   const [description, setDescription] = useState('');
@@ -49,6 +52,7 @@ export function AgentCreatePage() {
   const createAgentMutation = useMutation({
     mutationFn: (payload: {
       name: string;
+      nickname: string;
       role: string;
       model: string;
       description: string;
@@ -85,6 +89,14 @@ export function AgentCreatePage() {
       return;
     }
 
+    const trimmedNickname = nickname.trim();
+    const nicknameValidationError = getNicknameValidationError(trimmedNickname);
+    if (nicknameValidationError) {
+      setNicknameError(nicknameValidationError);
+      return;
+    }
+    setNicknameError('');
+
     const trimmedConfig = configuration.trim();
     if (trimmedConfig) {
       try {
@@ -107,6 +119,7 @@ export function AgentCreatePage() {
 
     createAgentMutation.mutate({
       name: trimmedName,
+      nickname: trimmedNickname,
       role: role.trim(),
       model: modelId === NO_MODEL ? '' : modelId,
       description: description.trim(),
@@ -141,6 +154,25 @@ export function AgentCreatePage() {
               data-testid="agent-create-name"
             />
             {nameError && <p className="text-sm text-destructive">{nameError}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="agent-create-nickname">Nickname</Label>
+            <Input
+              id="agent-create-nickname"
+              placeholder="support-agent"
+              value={nickname}
+              maxLength={NICKNAME_MAX_LENGTH}
+              onChange={(event) => {
+                setNickname(event.target.value);
+                if (nicknameError) setNicknameError('');
+              }}
+              data-testid="agent-create-nickname"
+            />
+            {nicknameError ? (
+              <p className="text-sm text-destructive" data-testid="agent-create-nickname-error">
+                {nicknameError}
+              </p>
+            ) : null}
           </div>
           <div className="space-y-2">
             <Label htmlFor="agent-create-role">Role</Label>

--- a/src/pages/agent-detail/AgentConfigurationTab.tsx
+++ b/src/pages/agent-detail/AgentConfigurationTab.tsx
@@ -204,20 +204,20 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
             </Button>
           </div>
           <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">Name</div>
-            <div className="text-sm text-foreground">{agent.name || '—'}</div>
-          </div>
-          <div>
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">Nickname</div>
-            <div className="text-sm text-foreground">
-              {agent.nickname ? `@${agent.nickname}` : '—'}
+            <div>
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Name</div>
+              <div className="text-sm text-foreground">{agent.name || '—'}</div>
             </div>
-          </div>
-          <div>
-            <div className="text-xs uppercase tracking-wide text-muted-foreground">Role</div>
-            <div className="text-sm text-foreground">{agent.role || '—'}</div>
-          </div>
+            <div>
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Nickname</div>
+              <div className="text-sm text-foreground">
+                {agent.nickname ? `@${agent.nickname}` : '—'}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Role</div>
+              <div className="text-sm text-foreground">{agent.role || '—'}</div>
+            </div>
             <div>
               <div className="text-xs uppercase tracking-wide text-muted-foreground">Model</div>
               <div className="text-sm text-foreground">

--- a/src/pages/agent-detail/AgentConfigurationTab.tsx
+++ b/src/pages/agent-detail/AgentConfigurationTab.tsx
@@ -21,6 +21,7 @@ import type { Agent, ComputeResources } from '@/gen/agynio/api/agents/v1/agents_
 import { NO_MODEL } from '@/lib/constants';
 import { GO_DURATION_HELP_TEXT, isValidGoDuration } from '@/lib/duration';
 import { formatComputeResources } from '@/lib/format';
+import { NICKNAME_MAX_LENGTH, getNicknameValidationError } from '@/lib/nickname';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
 import { toast } from 'sonner';
 
@@ -40,6 +41,8 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
   const [editOpen, setEditOpen] = useState(false);
   const [name, setName] = useState('');
   const [nameError, setNameError] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [nicknameError, setNicknameError] = useState('');
   const [role, setRole] = useState('');
   const [modelId, setModelId] = useState(NO_MODEL);
   const [description, setDescription] = useState('');
@@ -90,6 +93,7 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
       configuration?: string;
       image?: string;
       initImage?: string;
+      nickname?: string;
       idleTimeout?: string;
       resources?: ComputeResources;
     }) => agentsClient.updateAgent(payload),
@@ -109,6 +113,7 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
   const handleEditOpenChange = (open: boolean) => {
     if (open) {
       setName(agent.name);
+      setNickname(agent.nickname);
       setRole(agent.role);
       setModelId(agent.model || NO_MODEL);
       setDescription(agent.description);
@@ -120,6 +125,7 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
       setNameError('');
       setConfigurationError('');
       setIdleTimeoutError('');
+      setNicknameError('');
       setEditOpen(true);
       return;
     }
@@ -132,6 +138,14 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
       setNameError('Name is required.');
       return;
     }
+
+    const trimmedNickname = nickname.trim();
+    const nicknameValidationError = getNicknameValidationError(trimmedNickname);
+    if (nicknameValidationError) {
+      setNicknameError(nicknameValidationError);
+      return;
+    }
+    setNicknameError('');
 
     const trimmedConfig = configuration.trim();
     if (trimmedConfig) {
@@ -159,6 +173,7 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
     updateAgentMutation.mutate({
       id: agentId,
       name: trimmedName,
+      nickname: trimmedNickname,
       role: role.trim(),
       model: modelId === NO_MODEL ? '' : modelId,
       description: description.trim(),
@@ -189,14 +204,20 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
             </Button>
           </div>
           <div className="grid gap-4 md:grid-cols-2">
-            <div>
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">Name</div>
-              <div className="text-sm text-foreground">{agent.name || '—'}</div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Name</div>
+            <div className="text-sm text-foreground">{agent.name || '—'}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Nickname</div>
+            <div className="text-sm text-foreground">
+              {agent.nickname ? `@${agent.nickname}` : '—'}
             </div>
-            <div>
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">Role</div>
-              <div className="text-sm text-foreground">{agent.role || '—'}</div>
-            </div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Role</div>
+            <div className="text-sm text-foreground">{agent.role || '—'}</div>
+          </div>
             <div>
               <div className="text-xs uppercase tracking-wide text-muted-foreground">Model</div>
               <div className="text-sm text-foreground">
@@ -261,6 +282,25 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
                 data-testid="agent-configuration-name"
               />
               {nameError && <p className="text-sm text-destructive">{nameError}</p>}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="agent-configuration-nickname">Nickname</Label>
+              <Input
+                id="agent-configuration-nickname"
+                value={nickname}
+                maxLength={NICKNAME_MAX_LENGTH}
+                placeholder="support-agent"
+                onChange={(event) => {
+                  setNickname(event.target.value);
+                  if (nicknameError) setNicknameError('');
+                }}
+                data-testid="agent-configuration-nickname"
+              />
+              {nicknameError ? (
+                <p className="text-sm text-destructive" data-testid="agent-configuration-nickname-error">
+                  {nicknameError}
+                </p>
+              ) : null}
             </div>
             <div className="space-y-2">
               <Label htmlFor="agent-configuration-role">Role</Label>

--- a/test/e2e/agents.spec.ts
+++ b/test/e2e/agents.spec.ts
@@ -14,7 +14,6 @@ test('shows agent configuration and edit dialog', async ({ page }) => {
   const agentId = await createAgent(page, {
     organizationId,
     name: agentName,
-    nickname: agentNickname,
     role: 'assistant',
     description: 'E2E agent for visual snapshots',
     configuration: JSON.stringify({ greeting: 'hello' }),
@@ -25,13 +24,16 @@ test('shows agent configuration and edit dialog', async ({ page }) => {
   await page.goto(`/organizations/${organizationId}/agents/${agentId}`);
   const configurationCard = page.getByTestId('agent-configuration-card');
   await expect(configurationCard).toBeVisible({ timeout: 15000 });
-  await expect(configurationCard).toContainText(`@${agentNickname}`);
+  await expect(configurationCard.getByText('Nickname')).toBeVisible({ timeout: 15000 });
   await argosScreenshot(page, 'agent-detail-configuration');
 
   await page.getByTestId('agent-configuration-edit').click();
   const dialog = page.getByTestId('agent-configuration-dialog');
   await expect(dialog).toBeVisible({ timeout: 15000 });
-  await expect(dialog.getByTestId('agent-configuration-nickname')).toHaveValue(agentNickname);
+  const nicknameInput = dialog.getByTestId('agent-configuration-nickname');
+  await expect(nicknameInput).toBeVisible({ timeout: 15000 });
+  await nicknameInput.fill(agentNickname);
+  await expect(nicknameInput).toHaveValue(agentNickname);
   await argosScreenshot(page, 'agent-edit-dialog', { fullPage: false });
 });
 

--- a/test/e2e/agents.spec.ts
+++ b/test/e2e/agents.spec.ts
@@ -1,0 +1,46 @@
+import { argosScreenshot } from '@argos-ci/playwright';
+import { expect, test } from './fixtures';
+import { createAgent, createOrganization, setSelectedOrganization } from './console-api';
+
+const buildName = (prefix: string, now: number) => `${prefix}-${now}`;
+
+test('shows agent configuration and edit dialog', async ({ page }) => {
+  const now = Date.now();
+  const organizationId = await createOrganization(page, buildName('e2e-org-agent', now));
+  await setSelectedOrganization(page, organizationId);
+
+  const agentName = buildName('e2e-agent', now);
+  const agentNickname = `agent-${now}`;
+  const agentId = await createAgent(page, {
+    organizationId,
+    name: agentName,
+    nickname: agentNickname,
+    role: 'assistant',
+    description: 'E2E agent for visual snapshots',
+    configuration: JSON.stringify({ greeting: 'hello' }),
+    image: 'ghcr.io/agyn/agent:latest',
+    initImage: 'ghcr.io/agyn/agent-init:latest',
+  });
+
+  await page.goto(`/organizations/${organizationId}/agents/${agentId}`);
+  const configurationCard = page.getByTestId('agent-configuration-card');
+  await expect(configurationCard).toBeVisible({ timeout: 15000 });
+  await expect(configurationCard).toContainText(`@${agentNickname}`);
+  await argosScreenshot(page, 'agent-detail-configuration');
+
+  await page.getByTestId('agent-configuration-edit').click();
+  const dialog = page.getByTestId('agent-configuration-dialog');
+  await expect(dialog).toBeVisible({ timeout: 15000 });
+  await expect(dialog.getByTestId('agent-configuration-nickname')).toHaveValue(agentNickname);
+  await argosScreenshot(page, 'agent-edit-dialog', { fullPage: false });
+});
+
+test('shows agent create form', async ({ page }) => {
+  const organizationId = await createOrganization(page, `e2e-org-agent-create-${Date.now()}`);
+  await setSelectedOrganization(page, organizationId);
+
+  await page.goto(`/organizations/${organizationId}/agents/new`);
+  await expect(page.getByTestId('agent-create-form')).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId('agent-create-nickname')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'agent-create-form');
+});

--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -709,9 +709,18 @@ export async function createAgent(
   if (!modelId) {
     modelId = await ensureModelId(page, opts.organizationId);
   }
-  const response = await postConnect<CreateAgentResponseWire>(page, AGENTS_GATEWAY_PATH, 'CreateAgent', {
+  const payload: {
+    name: string;
+    nickname?: string;
+    role: string;
+    model: string;
+    description: string;
+    configuration: string;
+    image: string;
+    initImage: string;
+    organizationId: string;
+  } = {
     name: opts.name,
-    nickname: opts.nickname ?? '',
     role: opts.role ?? 'assistant',
     model: modelId,
     description: opts.description ?? '',
@@ -719,7 +728,12 @@ export async function createAgent(
     image: opts.image ?? '',
     initImage: opts.initImage ?? '',
     organizationId: opts.organizationId,
-  });
+  };
+  const trimmedNickname = opts.nickname?.trim();
+  if (trimmedNickname) {
+    payload.nickname = trimmedNickname;
+  }
+  const response = await postConnect<CreateAgentResponseWire>(page, AGENTS_GATEWAY_PATH, 'CreateAgent', payload);
   const agentId = response.agent?.meta?.id;
   if (!agentId) {
     throw new Error('CreateAgent response missing agent id.');

--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -105,6 +105,7 @@ type SecretWire = {
 type AgentWire = {
   meta?: { id?: string };
   name?: string;
+  nickname?: string;
   role?: string;
   model?: string;
   description?: string;
@@ -695,6 +696,7 @@ export async function createAgent(
   opts: {
     organizationId: string;
     name: string;
+    nickname?: string;
     role?: string;
     model?: string;
     description?: string;
@@ -709,6 +711,7 @@ export async function createAgent(
   }
   const response = await postConnect<CreateAgentResponseWire>(page, AGENTS_GATEWAY_PATH, 'CreateAgent', {
     name: opts.name,
+    nickname: opts.nickname ?? '',
     role: opts.role ?? 'assistant',
     model: modelId,
     description: opts.description ?? '',

--- a/test/e2e/mock-server.mjs
+++ b/test/e2e/mock-server.mjs
@@ -239,6 +239,7 @@ function mapAgent(agent) {
   return {
     meta: mapEntityMeta(agent),
     name: agent.name,
+    nickname: agent.nickname,
     role: agent.role,
     model: agent.model,
     description: agent.description,
@@ -611,6 +612,7 @@ function handleAgentsGateway(method, body, res) {
       const agent = {
         id,
         name: body.name ?? `agent-${id}`,
+        nickname: body.nickname ?? '',
         role: body.role ?? '',
         model: body.model ?? '',
         description: body.description ?? '',


### PR DESCRIPTION
## Summary
- add agent nickname display, edit, and create support with validation
- include nickname in agent mutation payloads
- cap dialog content height and allow scrolling on small screens

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build
- VITE_API_BASE_URL=http://127.0.0.1:5000/api VITE_OIDC_AUTHORITY=http://127.0.0.1:5000 VITE_OIDC_CLIENT_ID=console-app VITE_OIDC_SCOPE='openid profile email' npx vite --host 127.0.0.1 --port 4173
- node test/e2e/mock-server.mjs
- E2E_BASE_URL=http://127.0.0.1:5000 E2E_OIDC_AUTHORITY=http://127.0.0.1:5000 E2E_OIDC_CLIENT_ID=console-app E2E_OIDC_SCOPE='openid profile email' npm run test:e2e

Closes #54