### PR TITLE
Handle OIDC auth errors

### DIFF
--- a/src/auth/AuthGate.tsx
+++ b/src/auth/AuthGate.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { AuthProvider, useAuth } from 'react-oidc-context';
 import { Button } from '@/components/ui/button';
 import { oidcConfig } from '@/config';
@@ -32,12 +32,22 @@ function hasAuthParams(location = window.location): boolean {
   return false;
 }
 
-function SignedOutScreen({ onSignIn }: { onSignIn: () => void }) {
+type SignedOutScreenProps = {
+  onSignIn: () => void;
+  title?: string;
+  subtitle?: string;
+};
+
+function SignedOutScreen({
+  onSignIn,
+  title = 'You have signed out.',
+  subtitle = 'Sign back in to continue.',
+}: SignedOutScreenProps) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted/40">
       <div className="rounded-lg border bg-background px-6 py-5 text-center shadow-sm">
-        <div className="text-sm font-medium text-foreground">You have signed out.</div>
-        <div className="mt-1 text-xs text-muted-foreground">Sign back in to continue.</div>
+        <div className="text-sm font-medium text-foreground">{title}</div>
+        <div className="mt-1 text-xs text-muted-foreground">{subtitle}</div>
         <Button className="mt-4" size="sm" onClick={onSignIn}>
           Sign in
         </Button>
@@ -86,8 +96,30 @@ function RequireAuth({ children }: { children: ReactNode }) {
 
 function AuthErrorBoundary({ children }: { children: ReactNode }) {
   const auth = useAuth();
-  if (auth.error) {
-    throw new Error(`OIDC authentication failed: ${auth.error.message}`);
+  const { error, removeUser, signinRedirect } = auth;
+  const lastErrorRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!error) {
+      lastErrorRef.current = null;
+      return;
+    }
+    if (error.message === lastErrorRef.current) return;
+    lastErrorRef.current = error.message;
+    console.warn('OIDC error, redirecting to sign-in', error);
+    void removeUser().catch((removeError) => {
+      console.warn('Failed to clear OIDC user session.', removeError);
+    });
+  }, [error, removeUser]);
+
+  if (error) {
+    return (
+      <SignedOutScreen
+        onSignIn={() => void signinRedirect()}
+        title="We couldn't sign you in."
+        subtitle="Please sign in again to continue."
+      />
+    );
   }
   return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- show sign-in screen when OIDC errors occur
- clear auth state and log warnings without crashing

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #56