### PR TITLE
feat(layout): move settings links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # console-app
+
+## Navigation
+
+Devices, API Tokens, and Settings now live in the top-right user dropdown menu in the AppLayout header.

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
+import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 import {
   ActivityIcon,
   BotIcon,
@@ -126,6 +126,7 @@ export function AppLayout() {
   } = useOrganizationContext();
   const { currentUser, isClusterAdmin, status: userStatus, error: userError, signOut } = useUserContext();
   const pageTitle = usePageTitle();
+  const navigate = useNavigate();
 
   if (userStatus === 'loading' || orgStatus === 'loading') {
     return (
@@ -177,6 +178,19 @@ export function AppLayout() {
           Cluster role: {isClusterAdmin ? 'admin' : 'none'}
         </DropdownMenuItem>
         <PendingInvitesMenu />
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => navigate('/devices')} data-testid="user-menu-devices">
+          <MonitorSmartphoneIcon className="h-4 w-4" />
+          Devices
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => navigate('/api-tokens')} data-testid="user-menu-api-tokens">
+          <KeyIcon className="h-4 w-4" />
+          API Tokens
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => navigate('/settings')} data-testid="user-menu-settings">
+          <SettingsIcon className="h-4 w-4" />
+          Settings
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => signOut()} data-testid="user-menu-signout">
           Log out
@@ -346,20 +360,6 @@ export function AppLayout() {
             </nav>
           </div>
         ) : null}
-        <div className="mt-auto space-y-4">
-          <NavLink to="/devices" className={navLinkClass} data-testid="nav-devices">
-            <MonitorSmartphoneIcon className="h-4 w-4" />
-            Devices
-          </NavLink>
-          <NavLink to="/api-tokens" className={navLinkClass} data-testid="nav-api-tokens">
-            <KeyIcon className="h-4 w-4" />
-            API Tokens
-          </NavLink>
-          <NavLink to="/settings" className={navLinkClass} data-testid="nav-settings">
-            <SettingsIcon className="h-4 w-4" />
-            Settings
-          </NavLink>
-        </div>
       </aside>
       <main className="flex flex-1 flex-col">
         <header className="flex items-center justify-between border-b border-border bg-background px-6 py-4">

--- a/test/e2e/mock-server.mjs
+++ b/test/e2e/mock-server.mjs
@@ -1,7 +1,10 @@
 import http from 'node:http';
+import http2 from 'node:http2';
 import { randomUUID } from 'node:crypto';
+import { BinaryReader, WireType } from '@bufbuild/protobuf/wire';
 
 const port = Number(process.env.MOCK_SERVER_PORT ?? 5000);
+const meteringPort = Number(process.env.MOCK_METERING_PORT ?? 50051);
 const proxyTarget = new URL(process.env.MOCK_PROXY_TARGET ?? 'http://127.0.0.1:4173');
 const defaultUserId = 'user-1';
 const defaultEmail = 'e2e-tester@agyn.test';
@@ -20,6 +23,7 @@ const hooks = new Map();
 const llmProviders = new Map();
 const models = new Map();
 const imagePullSecretAttachments = new Map();
+const usageTotals = new Map();
 
 const defaultUser = {
   id: defaultUserId,
@@ -161,6 +165,83 @@ function normalizeClusterRole(value) {
   if (typeof value === 'string') return value;
   if (value === 1) return 'CLUSTER_ROLE_ADMIN';
   return 'CLUSTER_ROLE_UNSPECIFIED';
+}
+
+function normalizeGranularity(value) {
+  if (typeof value === 'string') return value;
+  if (value === 1) return 'GRANULARITY_TOTAL';
+  if (value === 2) return 'GRANULARITY_DAY';
+  return 'GRANULARITY_UNSPECIFIED';
+}
+
+function resolveGroupValue(groupBy) {
+  if (!groupBy) return '';
+  if (groupBy === 'status') return 'success';
+  if (groupBy === 'kind') return 'input';
+  if (groupBy === 'identity_id') return defaultUserId;
+  if (groupBy === 'resource_id') return defaultModel.id;
+  return 'unknown';
+}
+
+function normalizeInt64(value) {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return BigInt(value);
+  if (typeof value === 'string') return BigInt(value);
+  return 0n;
+}
+
+function recordUsageTotal(orgId, value) {
+  if (!orgId) return;
+  const total = usageTotals.get(orgId) ?? 0n;
+  usageTotals.set(orgId, total + value);
+}
+
+function parseUsageRecord(recordBytes) {
+  const reader = new BinaryReader(recordBytes);
+  let orgId = '';
+  let value = 0n;
+
+  while (reader.pos < reader.len) {
+    const [fieldNo, wireType] = reader.tag();
+    if (fieldNo === 1 && wireType === WireType.LengthDelimited) {
+      orgId = reader.string();
+      continue;
+    }
+    if (fieldNo === 7 && wireType === WireType.Varint) {
+      value = normalizeInt64(reader.int64());
+      continue;
+    }
+    reader.skip(wireType, fieldNo);
+  }
+
+  recordUsageTotal(orgId, value);
+}
+
+function parseRecordRequest(messageBytes) {
+  const reader = new BinaryReader(messageBytes);
+  while (reader.pos < reader.len) {
+    const [fieldNo, wireType] = reader.tag();
+    if (fieldNo === 1 && wireType === WireType.LengthDelimited) {
+      parseUsageRecord(reader.bytes());
+      continue;
+    }
+    reader.skip(wireType, fieldNo);
+  }
+}
+
+function parseGrpcRecordPayload(buffer) {
+  let offset = 0;
+  while (offset + 5 <= buffer.length) {
+    const compressed = buffer[offset];
+    const messageLength = buffer.readUInt32BE(offset + 1);
+    const start = offset + 5;
+    const end = start + messageLength;
+    if (end > buffer.length) return;
+    if (compressed === 0) {
+      parseRecordRequest(buffer.subarray(start, end));
+    }
+    offset = end;
+  }
 }
 
 function mapUser(user) {
@@ -776,6 +857,27 @@ function handleAppsGateway(method, _body, res) {
   return sendText(res, 404, 'Unknown AppsGateway method');
 }
 
+function handleMeteringGateway(method, body, res) {
+  if (method !== 'QueryUsage') {
+    return sendText(res, 404, 'Unknown MeteringGateway method');
+  }
+  const orgId = body.orgId ?? body.org_id ?? '';
+  const total = usageTotals.get(orgId) ?? 0n;
+  if (!orgId || total === 0n) {
+    return sendJson(res, 200, { buckets: [] });
+  }
+  const granularity = normalizeGranularity(body.granularity);
+  const groupValue = resolveGroupValue(body.groupBy ?? '');
+  const bucket = {
+    value: total.toString(),
+    groupValue,
+  };
+  if (granularity === 'GRANULARITY_DAY') {
+    bucket.timestamp = new Date().toISOString();
+  }
+  return sendJson(res, 200, { buckets: [bucket] });
+}
+
 async function handleLlmGateway(method, body, res) {
   switch (method) {
     case 'ListLLMProviders': {
@@ -835,6 +937,19 @@ async function handleLlmGateway(method, body, res) {
     default:
       return sendText(res, 404, 'Unknown LLMGateway method');
   }
+}
+
+const grpcEmptyMessage = Buffer.from([0, 0, 0, 0, 0]);
+
+function respondGrpc(stream, status, message) {
+  const headers = {
+    ':status': 200,
+    'content-type': 'application/grpc+proto',
+    'grpc-status': String(status),
+  };
+  if (message) headers['grpc-message'] = message;
+  stream.respond(headers);
+  stream.end(grpcEmptyMessage);
 }
 
 const server = http.createServer(async (req, res) => {
@@ -934,6 +1049,9 @@ const server = http.createServer(async (req, res) => {
     if (service === 'agynio.api.gateway.v1.AgentsGateway') {
       return handleAgentsGateway(method, body, res);
     }
+    if (service === 'agynio.api.gateway.v1.MeteringGateway') {
+      return handleMeteringGateway(method, body, res);
+    }
     if (service === 'agynio.api.gateway.v1.LLMGateway') {
       await handleLlmGateway(method, body, res);
       return;
@@ -949,4 +1067,32 @@ const server = http.createServer(async (req, res) => {
 
 server.listen(port, () => {
   console.log(`[mock-server] listening on ${port}`);
+});
+
+const meteringServer = http2.createServer();
+
+meteringServer.on('stream', (stream, headers) => {
+  const path = headers[':path'];
+  if (path === '/agynio.api.metering.v1.MeteringService/Record') {
+    const chunks = [];
+    stream.on('data', (chunk) => chunks.push(chunk));
+    stream.on('end', () => {
+      try {
+        const payload = Buffer.concat(chunks);
+        if (payload.length > 0) {
+          parseGrpcRecordPayload(payload);
+        }
+      } catch {
+        // ignore malformed payloads in mock
+      }
+      respondGrpc(stream, 0);
+    });
+    return;
+  }
+
+  respondGrpc(stream, 12, 'unimplemented');
+});
+
+meteringServer.listen(meteringPort, () => {
+  console.log(`[mock-metering] listening on ${meteringPort}`);
 });

--- a/test/e2e/settings.spec.ts
+++ b/test/e2e/settings.spec.ts
@@ -2,7 +2,11 @@ import { argosScreenshot } from '@argos-ci/playwright';
 import { test, expect } from './fixtures';
 
 test('shows settings profile info', async ({ page }) => {
-  await page.goto('/settings');
+  await page.goto('/');
+  await expect(page.getByTestId('user-menu-trigger')).toBeVisible({ timeout: 15000 });
+  await page.getByTestId('user-menu-trigger').click();
+  await page.getByTestId('user-menu-settings').click();
+  await expect(page).toHaveURL(/\/settings$/);
   await expect(page.getByTestId('settings-profile-card')).toBeVisible({ timeout: 15000 });
   await argosScreenshot(page, 'settings-profile');
 });

--- a/test/e2e/sign-out.spec.ts
+++ b/test/e2e/sign-out.spec.ts
@@ -8,6 +8,9 @@ test('signs out from user menu', async ({ page }) => {
 
   await expect(page.getByTestId('user-menu-trigger')).toBeVisible({ timeout: 15000 });
   await page.getByTestId('user-menu-trigger').click();
+  await expect(page.getByTestId('user-menu-devices')).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId('user-menu-api-tokens')).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId('user-menu-settings')).toBeVisible({ timeout: 15000 });
   await page.getByTestId('user-menu-signout').click({ noWaitAfter: true });
 
   await page.waitForFunction(() => {


### PR DESCRIPTION
## Summary
- move Devices/API Tokens/Settings into the header user dropdown
- update e2e navigation coverage and settings entry point
- add metering mock support for usage tests and note the nav change in README

## Testing
- npm run generate
- npm run lint
- npm run typecheck
- npm run test
- VITE_OIDC_AUTHORITY=http://127.0.0.1:5000 VITE_OIDC_CLIENT_ID=console-app VITE_OIDC_SCOPE='openid profile email' npm run build
- E2E_BASE_URL=http://127.0.0.1:5000 E2E_OIDC_AUTHORITY=http://127.0.0.1:5000 E2E_OIDC_CLIENT_ID=console-app E2E_OIDC_SCOPE='openid profile email' METERING_GRPC_URL=http://127.0.0.1:50051 npm run test:e2e

Closes #59