### PR TITLE
fix(layout): keep sidebar sticky

### DIFF
--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -63,7 +63,7 @@ function NoAccessScreen({ onSignOut, userMenu, pendingMembershipsCount }: NoAcce
   return (
     <>
       <div className="flex min-h-screen flex-col bg-muted/40">
-        <header className="flex items-center justify-end border-b border-border bg-background px-6 py-4">
+        <header className="sticky top-0 z-10 flex items-center justify-end border-b border-border bg-background px-6 py-4">
           <div className="flex items-center gap-2">
             <ThemeToggle />
             {userMenu}
@@ -218,7 +218,7 @@ export function AppLayout() {
   return (
     <div className="flex min-h-screen bg-muted/40">
       <aside
-        className="flex w-64 flex-col border-r border-sidebar-border bg-sidebar px-4 py-6 text-sidebar-foreground"
+        className="sticky top-0 flex h-screen w-64 flex-col overflow-y-auto border-r border-sidebar-border bg-sidebar px-4 py-6 text-sidebar-foreground"
         data-testid="console-sidebar"
       >
         {isClusterContext ? (
@@ -362,7 +362,7 @@ export function AppLayout() {
         ) : null}
       </aside>
       <main className="flex flex-1 flex-col">
-        <header className="flex items-center justify-between border-b border-border bg-background px-6 py-4">
+        <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background px-6 py-4">
           <h1 className="text-lg font-semibold text-foreground" data-testid="page-title">
             {pageTitle}
           </h1>


### PR DESCRIPTION
## Summary
- keep sidebar sticky with full-height scrolling
- make headers sticky for top-bar consistency

## Testing
- npm run generate
- npm run lint
- npm run typecheck
- npm run test
- VITE_OIDC_AUTHORITY=http://127.0.0.1:5000 VITE_OIDC_CLIENT_ID=console-app VITE_OIDC_SCOPE='openid profile email' npm run build
- E2E_BASE_URL=http://127.0.0.1:5000 E2E_OIDC_AUTHORITY=http://127.0.0.1:5000 E2E_OIDC_CLIENT_ID=console-app E2E_OIDC_SCOPE='openid profile email' METERING_GRPC_URL=http://127.0.0.1:50051 npm run test:e2e

Closes #61