### PR TITLE
Fix route guard context sync

### DIFF
--- a/src/__tests__/route-guards.test.tsx
+++ b/src/__tests__/route-guards.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import type { OrganizationSummary } from '@/context/OrganizationContext';
 import type { useOrganizationContext } from '@/context/OrganizationContext';
 import type { useUserContext } from '@/context/UserContext';
@@ -21,6 +21,10 @@ vi.mock('@/context/OrganizationContext', () => ({
 }));
 
 describe('route guards', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     userContext = {
       currentUser: null,
@@ -114,5 +118,69 @@ describe('route guards', () => {
     );
 
     expect(screen.getByText('Org list')).toBeTruthy();
+  });
+
+  it('does not override cluster context on organization routes', () => {
+    const orgTwo: OrganizationSummary = {
+      id: 'org-2',
+      name: 'Org Two',
+    };
+
+    orgContext.contextMode = { mode: 'cluster' };
+    orgContext.organizations = [orgTwo];
+
+    render(
+      <MemoryRouter initialEntries={['/organizations/org-2']}>
+        <Routes>
+          <Route
+            path="/organizations/:id"
+            element={
+              <RequireOrganization>
+                <div>Org detail</div>
+              </RequireOrganization>
+            }
+          />
+          <Route path="/organizations" element={<div>Org list</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Org detail')).toBeTruthy();
+    expect(orgContext.setContextMode).not.toHaveBeenCalled();
+  });
+
+  it('syncs context with deep-linked organization routes', async () => {
+    const orgOne: OrganizationSummary = {
+      id: 'org-1',
+      name: 'Org One',
+    };
+    const orgTwo: OrganizationSummary = {
+      id: 'org-2',
+      name: 'Org Two',
+    };
+
+    orgContext.contextMode = { mode: 'organization', organization: orgOne };
+    orgContext.selectedOrganization = orgOne;
+    orgContext.organizations = [orgOne, orgTwo];
+
+    render(
+      <MemoryRouter initialEntries={['/organizations/org-2']}>
+        <Routes>
+          <Route
+            path="/organizations/:id"
+            element={
+              <RequireOrganization>
+                <div>Org detail</div>
+              </RequireOrganization>
+            }
+          />
+          <Route path="/organizations" element={<div>Org list</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(orgContext.setContextMode).toHaveBeenCalledWith({ mode: 'organization', organization: orgTwo });
+    });
   });
 });

--- a/src/components/RouteGuards.tsx
+++ b/src/components/RouteGuards.tsx
@@ -30,7 +30,7 @@ export function RequireClusterAdmin({ children }: GuardProps) {
 }
 
 export function RequireOrganization({ children }: GuardProps) {
-  const { selectedOrganization, status, error, organizations, setContextMode } = useOrganizationContext();
+  const { selectedOrganization, status, error, organizations, setContextMode, contextMode } = useOrganizationContext();
   const location = useLocation();
   const params = useParams();
   const orgId = params.id;
@@ -40,11 +40,12 @@ export function RequireOrganization({ children }: GuardProps) {
   useEffect(() => {
     if (status !== 'ready') return;
     if (!orgId) return;
+    if (contextMode?.mode === 'cluster') return;
     if (selectedOrganization?.id === orgId) return;
     if (matchingOrganization) {
       setContextMode({ mode: 'organization', organization: matchingOrganization });
     }
-  }, [matchingOrganization, orgId, selectedOrganization, setContextMode, status]);
+  }, [contextMode, matchingOrganization, orgId, selectedOrganization, setContextMode, status]);
 
   if (status === 'loading') {
     return <div className="text-sm text-muted-foreground">Loading organizations...</div>;


### PR DESCRIPTION
## Summary
- prevent RequireOrganization from overwriting cluster context mode
- add route guard tests for cluster mode and deep-link sync coverage

## Testing
- npm run lint
- npm run test

#63