### PR TITLE
feat: add org runner detail view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,7 +117,7 @@ export default function App() {
           }
         />
         <Route
-          path="runners/:id"
+          path="runners/:runnerId"
           element={
             <RequireClusterAdmin>
               <RunnerDetailPage />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ export default function App() {
           <Route path="image-pull-secrets" element={<OrganizationImagePullSecretsTab />} />
           <Route path="secret-providers" element={<OrganizationSecretProvidersTab />} />
           <Route path="runners" element={<OrganizationRunnersTab />} />
+          <Route path="runners/:runnerId" element={<RunnerDetailPage />} />
           <Route path="apps" element={<OrganizationAppsTab />} />
           <Route path="apps/:appId" element={<AppDetailPage />} />
           <Route path="monitoring" element={<OrganizationMonitoringTab />} />

--- a/src/pages/OrganizationRunnersTab.tsx
+++ b/src/pages/OrganizationRunnersTab.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { NavLink, useParams } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { runnersClient } from '@/api/client';
 import { SortableHeader } from '@/components/SortableHeader';
@@ -9,6 +9,8 @@ import { EnrollRunnerDialog } from '@/components/EnrollRunnerDialog';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useUserContext } from '@/context/UserContext';
 import { formatLabelPairs, formatRunnerStatus } from '@/lib/format';
 import { DEFAULT_PAGE_SIZE } from '@/lib/pagination';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -20,6 +22,7 @@ export function OrganizationRunnersTab() {
   const { id } = useParams();
   const organizationId = id ?? '';
   const [enrollOpen, setEnrollOpen] = useState(false);
+  const { isClusterAdmin } = useUserContext();
 
   const runnersQuery = useInfiniteQuery({
     queryKey: ['runners', organizationId, 'list'],
@@ -32,17 +35,21 @@ export function OrganizationRunnersTab() {
     refetchOnWindowFocus: false,
   });
   const runners = runnersQuery.data?.pages.flatMap((page) => page.runners) ?? [];
+  const getScopeLabel = (runner: (typeof runners)[number]) =>
+    runner.organizationId ? 'Organization' : 'Cluster';
   const listControls = useListControls({
     items: runners,
     searchFields: [
       (runner) => runner.name,
       (runner) => runner.meta?.id ?? '',
       (runner) => formatRunnerStatus(runner.status),
+      (runner) => getScopeLabel(runner),
       (runner) => formatLabelPairs(runner.labels),
     ],
     sortOptions: {
       name: (runner) => runner.name,
       status: (runner) => formatRunnerStatus(runner.status),
+      scope: (runner) => getScopeLabel(runner),
       labels: (runner) => formatLabelPairs(runner.labels),
     },
     defaultSortKey: 'name',
@@ -50,89 +57,245 @@ export function OrganizationRunnersTab() {
 
   const visibleRunners = listControls.filteredItems;
   const hasSearch = listControls.searchTerm.trim().length > 0;
+  const organizationRunners = visibleRunners.filter((runner) => runner.organizationId === organizationId);
+  const clusterRunners = visibleRunners.filter((runner) => !runner.organizationId);
+
+  const renderOrgRunnerView = (runnerId?: string | null) => {
+    if (!runnerId || !organizationId) {
+      return (
+        <Button variant="outline" size="sm" disabled data-testid="organization-runner-view">
+          View
+        </Button>
+      );
+    }
+
+    return (
+      <Button variant="outline" size="sm" asChild>
+        <NavLink to={`/organizations/${organizationId}/runners/${runnerId}`} data-testid="organization-runner-view">
+          View
+        </NavLink>
+      </Button>
+    );
+  };
+
+  const renderClusterRunnerView = (runnerId?: string | null) => {
+    if (!runnerId) {
+      return (
+        <Button variant="outline" size="sm" disabled data-testid="organization-cluster-runner-view">
+          View
+        </Button>
+      );
+    }
+
+    if (isClusterAdmin) {
+      return (
+        <Button variant="outline" size="sm" asChild>
+          <NavLink to={`/runners/${runnerId}`} data-testid="organization-cluster-runner-view">
+            View
+          </NavLink>
+        </Button>
+      );
+    }
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-block">
+            <Button variant="outline" size="sm" disabled data-testid="organization-cluster-runner-view">
+              View
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6}>
+          Cluster runners are only available to cluster admins.
+        </TooltipContent>
+      </Tooltip>
+    );
+  };
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="max-w-sm flex-1">
-          <Input
-            placeholder="Search runners..."
-            value={listControls.searchTerm}
-            onChange={(event) => listControls.setSearchTerm(event.target.value)}
-            data-testid="list-search"
-          />
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setEnrollOpen(true)}
-          data-testid="organization-runners-enroll"
-        >
-          Enroll runner
-        </Button>
+    <div className="space-y-6">
+      <div className="max-w-sm">
+        <Input
+          placeholder="Search runners..."
+          value={listControls.searchTerm}
+          onChange={(event) => listControls.setSearchTerm(event.target.value)}
+          data-testid="list-search"
+        />
       </div>
       {runnersQuery.isPending ? <div className="text-sm text-muted-foreground">Loading runners...</div> : null}
       {runnersQuery.isError ? <div className="text-sm text-muted-foreground">Failed to load runners.</div> : null}
-      <Card className="border-border" data-testid="organization-runners-table">
-        <CardContent className="px-0">
-          <div
-            className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_1fr_2fr]"
-            data-testid="organization-runners-header"
-          >
-            <SortableHeader
-              label="Runner"
-              sortKey="name"
-              activeSortKey={listControls.sortKey}
-              sortDirection={listControls.sortDirection}
-              onSort={listControls.handleSort}
-            />
-            <SortableHeader
-              label="Status"
-              sortKey="status"
-              activeSortKey={listControls.sortKey}
-              sortDirection={listControls.sortDirection}
-              onSort={listControls.handleSort}
-            />
-            <SortableHeader
-              label="Labels"
-              sortKey="labels"
-              activeSortKey={listControls.sortKey}
-              sortDirection={listControls.sortDirection}
-              onSort={listControls.handleSort}
-            />
+      <div className="space-y-6">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h3 className="text-base font-semibold text-foreground">Organization Runners</h3>
+              <p className="text-sm text-muted-foreground">Runners scoped to this organization.</p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setEnrollOpen(true)}
+              data-testid="organization-runners-enroll"
+            >
+              Enroll runner
+            </Button>
           </div>
-          <div className="divide-y divide-border">
-            {visibleRunners.length === 0 ? (
-              <div className="px-6 py-6 text-sm text-muted-foreground">
-                {hasSearch ? 'No results found.' : 'No runners registered.'}
+          <Card className="border-border" data-testid="organization-runners-table">
+            <CardContent className="px-0">
+              <div
+                className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_1fr_1fr_2fr_120px]"
+                data-testid="organization-runners-header"
+              >
+                <SortableHeader
+                  label="Runner"
+                  sortKey="name"
+                  activeSortKey={listControls.sortKey}
+                  sortDirection={listControls.sortDirection}
+                  onSort={listControls.handleSort}
+                />
+                <SortableHeader
+                  label="Status"
+                  sortKey="status"
+                  activeSortKey={listControls.sortKey}
+                  sortDirection={listControls.sortDirection}
+                  onSort={listControls.handleSort}
+                />
+                <SortableHeader
+                  label="Scope"
+                  sortKey="scope"
+                  activeSortKey={listControls.sortKey}
+                  sortDirection={listControls.sortDirection}
+                  onSort={listControls.handleSort}
+                />
+                <SortableHeader
+                  label="Labels"
+                  sortKey="labels"
+                  activeSortKey={listControls.sortKey}
+                  sortDirection={listControls.sortDirection}
+                  onSort={listControls.handleSort}
+                />
+                <span className="text-right">Action</span>
               </div>
-            ) : (
-              visibleRunners.map((runner) => (
-                <div
-                  key={runner.meta?.id ?? runner.name}
-                  className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_2fr]"
-                  data-testid="organization-runner-row"
-                >
-                  <div>
-                    <div className="font-medium" data-testid="organization-runner-name">
-                      {runner.name}
-                    </div>
-                    <div className="text-xs text-muted-foreground" data-testid="organization-runner-id">
-                      {runner.meta?.id}
-                    </div>
+              <div className="divide-y divide-border">
+                {organizationRunners.length === 0 ? (
+                  <div className="px-6 py-6 text-sm text-muted-foreground">
+                    {hasSearch ? 'No results found.' : 'No organization runners registered.'}
                   </div>
-                  <Badge variant="secondary" data-testid="organization-runner-status">
-                    {formatRunnerStatus(runner.status)}
-                  </Badge>
-                  <span className="text-xs text-muted-foreground" data-testid="organization-runner-labels">
-                    {formatLabelPairs(runner.labels)}
-                  </span>
-                </div>
-              ))
-            )}
+                ) : (
+                  organizationRunners.map((runner) => (
+                    <div
+                      key={runner.meta?.id ?? runner.name}
+                      className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_1fr_2fr_120px]"
+                      data-testid="organization-runner-row"
+                    >
+                      <div>
+                        <div className="font-medium" data-testid="organization-runner-name">
+                          {runner.name}
+                        </div>
+                        <div className="text-xs text-muted-foreground" data-testid="organization-runner-id">
+                          {runner.meta?.id}
+                        </div>
+                      </div>
+                      <Badge variant="secondary" data-testid="organization-runner-status">
+                        {formatRunnerStatus(runner.status)}
+                      </Badge>
+                      <Badge variant="outline" data-testid="organization-runner-scope">
+                        Organization
+                      </Badge>
+                      <span className="text-xs text-muted-foreground" data-testid="organization-runner-labels">
+                        {formatLabelPairs(runner.labels)}
+                      </span>
+                      <div className="text-right">{renderOrgRunnerView(runner.meta?.id)}</div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+        <div className="space-y-3">
+          <div>
+            <h3 className="text-base font-semibold text-foreground">Cluster Runners</h3>
+            <p className="text-sm text-muted-foreground">Shared runners available to this organization.</p>
           </div>
-        </CardContent>
-      </Card>
+          <Card className="border-border" data-testid="organization-cluster-runners-table">
+            <CardContent className="px-0">
+              <div
+                className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_1fr_1fr_2fr_120px]"
+                data-testid="organization-cluster-runners-header"
+              >
+                <SortableHeader
+                  label="Runner"
+                  sortKey="name"
+                  activeSortKey={listControls.sortKey}
+                  sortDirection={listControls.sortDirection}
+                  onSort={listControls.handleSort}
+                />
+                <SortableHeader
+                  label="Status"
+                  sortKey="status"
+                  activeSortKey={listControls.sortKey}
+                  sortDirection={listControls.sortDirection}
+                  onSort={listControls.handleSort}
+                />
+                <SortableHeader
+                  label="Scope"
+                  sortKey="scope"
+                  activeSortKey={listControls.sortKey}
+                  sortDirection={listControls.sortDirection}
+                  onSort={listControls.handleSort}
+                />
+                <SortableHeader
+                  label="Labels"
+                  sortKey="labels"
+                  activeSortKey={listControls.sortKey}
+                  sortDirection={listControls.sortDirection}
+                  onSort={listControls.handleSort}
+                />
+                <span className="text-right">Action</span>
+              </div>
+              <div className="divide-y divide-border">
+                {clusterRunners.length === 0 ? (
+                  <div className="px-6 py-6 text-sm text-muted-foreground">
+                    {hasSearch ? 'No results found.' : 'No cluster runners available.'}
+                  </div>
+                ) : (
+                  clusterRunners.map((runner) => (
+                    <div
+                      key={runner.meta?.id ?? runner.name}
+                      className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_1fr_2fr_120px]"
+                      data-testid="organization-cluster-runner-row"
+                    >
+                      <div>
+                        <div className="font-medium" data-testid="organization-cluster-runner-name">
+                          {runner.name}
+                        </div>
+                        <div className="text-xs text-muted-foreground" data-testid="organization-cluster-runner-id">
+                          {runner.meta?.id}
+                        </div>
+                      </div>
+                      <Badge variant="secondary" data-testid="organization-cluster-runner-status">
+                        {formatRunnerStatus(runner.status)}
+                      </Badge>
+                      <Badge variant="outline" data-testid="organization-cluster-runner-scope">
+                        Cluster
+                      </Badge>
+                      <span
+                        className="text-xs text-muted-foreground"
+                        data-testid="organization-cluster-runner-labels"
+                      >
+                        {formatLabelPairs(runner.labels)}
+                      </span>
+                      <div className="text-right">{renderClusterRunnerView(runner.meta?.id)}</div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
       <LoadMoreButton
         hasMore={Boolean(runnersQuery.hasNextPage)}
         isLoading={runnersQuery.isFetchingNextPage}

--- a/src/pages/OrganizationRunnersTab.tsx
+++ b/src/pages/OrganizationRunnersTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ChangeEvent, type ReactNode } from 'react';
 import { NavLink, useParams } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { runnersClient } from '@/api/client';
@@ -14,7 +14,140 @@ import { useUserContext } from '@/context/UserContext';
 import { formatLabelPairs, formatRunnerStatus } from '@/lib/format';
 import { DEFAULT_PAGE_SIZE } from '@/lib/pagination';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { useListControls } from '@/hooks/useListControls';
+import { useListControls, type SortDirection } from '@/hooks/useListControls';
+
+type Runner = Awaited<ReturnType<typeof runnersClient.listRunners>>['runners'][number];
+
+type RunnerSortKey = 'name' | 'status' | 'labels';
+
+type RunnerListControls = {
+  sortKey: RunnerSortKey;
+  sortDirection: SortDirection;
+  handleSort: (key: RunnerSortKey) => void;
+  filteredItems: Runner[];
+};
+
+type RunnerTableTestIds = {
+  table: string;
+  header: string;
+  row: string;
+  name: string;
+  id: string;
+  status: string;
+  labels: string;
+  scope: string;
+};
+
+type RunnerTableSectionProps = {
+  title: string;
+  description: string;
+  listControls: RunnerListControls;
+  hasSearch: boolean;
+  emptyMessage: string;
+  scopeLabel: string;
+  headerAction?: ReactNode;
+  renderAction: (runner: Runner) => ReactNode;
+  testIds: RunnerTableTestIds;
+};
+
+function RunnerTableSection({
+  title,
+  description,
+  listControls,
+  hasSearch,
+  emptyMessage,
+  scopeLabel,
+  headerAction,
+  renderAction,
+  testIds,
+}: RunnerTableSectionProps) {
+  const visibleRunners = listControls.filteredItems;
+  const emptyState = hasSearch ? 'No results found.' : emptyMessage;
+  const headerContent = (
+    <div>
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
+
+  return (
+    <div className="space-y-3">
+      {headerAction ? (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          {headerContent}
+          {headerAction}
+        </div>
+      ) : (
+        headerContent
+      )}
+      <Card className="border-border" data-testid={testIds.table}>
+        <CardContent className="px-0">
+          <div
+            className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_1fr_2fr_120px]"
+            data-testid={testIds.header}
+          >
+            <SortableHeader
+              label="Runner"
+              sortKey="name"
+              activeSortKey={listControls.sortKey}
+              sortDirection={listControls.sortDirection}
+              onSort={listControls.handleSort}
+            />
+            <SortableHeader
+              label="Status"
+              sortKey="status"
+              activeSortKey={listControls.sortKey}
+              sortDirection={listControls.sortDirection}
+              onSort={listControls.handleSort}
+            />
+            <SortableHeader
+              label="Labels"
+              sortKey="labels"
+              activeSortKey={listControls.sortKey}
+              sortDirection={listControls.sortDirection}
+              onSort={listControls.handleSort}
+            />
+            <span className="text-right">Action</span>
+          </div>
+          <div className="divide-y divide-border">
+            {visibleRunners.length === 0 ? (
+              <div className="px-6 py-6 text-sm text-muted-foreground">{emptyState}</div>
+            ) : (
+              visibleRunners.map((runner) => (
+                <div
+                  key={runner.meta?.id ?? runner.name}
+                  className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_2fr_120px]"
+                  data-testid={testIds.row}
+                >
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <div className="font-medium" data-testid={testIds.name}>
+                        {runner.name}
+                      </div>
+                      <Badge variant="outline" data-testid={testIds.scope}>
+                        {scopeLabel}
+                      </Badge>
+                    </div>
+                    <div className="text-xs text-muted-foreground" data-testid={testIds.id}>
+                      {runner.meta?.id}
+                    </div>
+                  </div>
+                  <Badge variant="secondary" data-testid={testIds.status}>
+                    {formatRunnerStatus(runner.status)}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground" data-testid={testIds.labels}>
+                    {formatLabelPairs(runner.labels)}
+                  </span>
+                  <div className="text-right">{renderAction(runner)}</div>
+                </div>
+              ))
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
 
 export function OrganizationRunnersTab() {
   useDocumentTitle('Runners');
@@ -35,32 +168,45 @@ export function OrganizationRunnersTab() {
     refetchOnWindowFocus: false,
   });
   const runners = runnersQuery.data?.pages.flatMap((page) => page.runners) ?? [];
-  const getScopeLabel = (runner: (typeof runners)[number]) =>
-    runner.organizationId ? 'Organization' : 'Cluster';
-  const listControls = useListControls({
-    items: runners,
-    searchFields: [
-      (runner) => runner.name,
-      (runner) => runner.meta?.id ?? '',
-      (runner) => formatRunnerStatus(runner.status),
-      (runner) => getScopeLabel(runner),
-      (runner) => formatLabelPairs(runner.labels),
-    ],
-    sortOptions: {
-      name: (runner) => runner.name,
-      status: (runner) => formatRunnerStatus(runner.status),
-      scope: (runner) => getScopeLabel(runner),
-      labels: (runner) => formatLabelPairs(runner.labels),
-    },
+  const getScopeLabel = (runner: Runner) => (runner.organizationId ? 'Organization' : 'Cluster');
+  const organizationRunners = runners.filter((runner) => runner.organizationId === organizationId);
+  const clusterRunners = runners.filter((runner) => !runner.organizationId);
+  const searchFields = [
+    (runner: Runner) => runner.name,
+    (runner: Runner) => runner.meta?.id ?? '',
+    (runner: Runner) => formatRunnerStatus(runner.status),
+    (runner: Runner) => getScopeLabel(runner),
+    (runner: Runner) => formatLabelPairs(runner.labels),
+  ];
+  const runnerSortOptions = {
+    name: (runner: Runner) => runner.name,
+    status: (runner: Runner) => formatRunnerStatus(runner.status),
+    labels: (runner: Runner) => formatLabelPairs(runner.labels),
+  };
+
+  const organizationListControls = useListControls({
+    items: organizationRunners,
+    searchFields,
+    sortOptions: runnerSortOptions,
+    defaultSortKey: 'name',
+  });
+  const clusterListControls = useListControls({
+    items: clusterRunners,
+    searchFields,
+    sortOptions: runnerSortOptions,
     defaultSortKey: 'name',
   });
 
-  const visibleRunners = listControls.filteredItems;
-  const hasSearch = listControls.searchTerm.trim().length > 0;
-  const organizationRunners = visibleRunners.filter((runner) => runner.organizationId === organizationId);
-  const clusterRunners = visibleRunners.filter((runner) => !runner.organizationId);
+  const hasSearch = organizationListControls.searchTerm.trim().length > 0;
 
-  const renderOrgRunnerView = (runnerId?: string | null) => {
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    organizationListControls.setSearchTerm(value);
+    clusterListControls.setSearchTerm(value);
+  };
+
+  const renderOrgRunnerView = (runner: Runner) => {
+    const runnerId = runner.meta?.id;
     if (!runnerId || !organizationId) {
       return (
         <Button variant="outline" size="sm" disabled data-testid="organization-runner-view">
@@ -78,7 +224,8 @@ export function OrganizationRunnersTab() {
     );
   };
 
-  const renderClusterRunnerView = (runnerId?: string | null) => {
+  const renderClusterRunnerView = (runner: Runner) => {
+    const runnerId = runner.meta?.id;
     if (!runnerId) {
       return (
         <Button variant="outline" size="sm" disabled data-testid="organization-cluster-runner-view">
@@ -113,188 +260,73 @@ export function OrganizationRunnersTab() {
     );
   };
 
+  const organizationTestIds: RunnerTableTestIds = {
+    table: 'organization-runners-table',
+    header: 'organization-runners-header',
+    row: 'organization-runner-row',
+    name: 'organization-runner-name',
+    id: 'organization-runner-id',
+    status: 'organization-runner-status',
+    labels: 'organization-runner-labels',
+    scope: 'organization-runner-scope',
+  };
+
+  const clusterTestIds: RunnerTableTestIds = {
+    table: 'organization-cluster-runners-table',
+    header: 'organization-cluster-runners-header',
+    row: 'organization-cluster-runner-row',
+    name: 'organization-cluster-runner-name',
+    id: 'organization-cluster-runner-id',
+    status: 'organization-cluster-runner-status',
+    labels: 'organization-cluster-runner-labels',
+    scope: 'organization-cluster-runner-scope',
+  };
+
+  const enrollAction = (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => setEnrollOpen(true)}
+      data-testid="organization-runners-enroll"
+    >
+      Enroll runner
+    </Button>
+  );
+
   return (
     <div className="space-y-6">
       <div className="max-w-sm">
         <Input
           placeholder="Search runners..."
-          value={listControls.searchTerm}
-          onChange={(event) => listControls.setSearchTerm(event.target.value)}
+          value={organizationListControls.searchTerm}
+          onChange={handleSearchChange}
           data-testid="list-search"
         />
       </div>
       {runnersQuery.isPending ? <div className="text-sm text-muted-foreground">Loading runners...</div> : null}
       {runnersQuery.isError ? <div className="text-sm text-muted-foreground">Failed to load runners.</div> : null}
       <div className="space-y-6">
-        <div className="space-y-3">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <h3 className="text-base font-semibold text-foreground">Organization Runners</h3>
-              <p className="text-sm text-muted-foreground">Runners scoped to this organization.</p>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setEnrollOpen(true)}
-              data-testid="organization-runners-enroll"
-            >
-              Enroll runner
-            </Button>
-          </div>
-          <Card className="border-border" data-testid="organization-runners-table">
-            <CardContent className="px-0">
-              <div
-                className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_1fr_1fr_2fr_120px]"
-                data-testid="organization-runners-header"
-              >
-                <SortableHeader
-                  label="Runner"
-                  sortKey="name"
-                  activeSortKey={listControls.sortKey}
-                  sortDirection={listControls.sortDirection}
-                  onSort={listControls.handleSort}
-                />
-                <SortableHeader
-                  label="Status"
-                  sortKey="status"
-                  activeSortKey={listControls.sortKey}
-                  sortDirection={listControls.sortDirection}
-                  onSort={listControls.handleSort}
-                />
-                <SortableHeader
-                  label="Scope"
-                  sortKey="scope"
-                  activeSortKey={listControls.sortKey}
-                  sortDirection={listControls.sortDirection}
-                  onSort={listControls.handleSort}
-                />
-                <SortableHeader
-                  label="Labels"
-                  sortKey="labels"
-                  activeSortKey={listControls.sortKey}
-                  sortDirection={listControls.sortDirection}
-                  onSort={listControls.handleSort}
-                />
-                <span className="text-right">Action</span>
-              </div>
-              <div className="divide-y divide-border">
-                {organizationRunners.length === 0 ? (
-                  <div className="px-6 py-6 text-sm text-muted-foreground">
-                    {hasSearch ? 'No results found.' : 'No organization runners registered.'}
-                  </div>
-                ) : (
-                  organizationRunners.map((runner) => (
-                    <div
-                      key={runner.meta?.id ?? runner.name}
-                      className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_1fr_2fr_120px]"
-                      data-testid="organization-runner-row"
-                    >
-                      <div>
-                        <div className="font-medium" data-testid="organization-runner-name">
-                          {runner.name}
-                        </div>
-                        <div className="text-xs text-muted-foreground" data-testid="organization-runner-id">
-                          {runner.meta?.id}
-                        </div>
-                      </div>
-                      <Badge variant="secondary" data-testid="organization-runner-status">
-                        {formatRunnerStatus(runner.status)}
-                      </Badge>
-                      <Badge variant="outline" data-testid="organization-runner-scope">
-                        Organization
-                      </Badge>
-                      <span className="text-xs text-muted-foreground" data-testid="organization-runner-labels">
-                        {formatLabelPairs(runner.labels)}
-                      </span>
-                      <div className="text-right">{renderOrgRunnerView(runner.meta?.id)}</div>
-                    </div>
-                  ))
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-        <div className="space-y-3">
-          <div>
-            <h3 className="text-base font-semibold text-foreground">Cluster Runners</h3>
-            <p className="text-sm text-muted-foreground">Shared runners available to this organization.</p>
-          </div>
-          <Card className="border-border" data-testid="organization-cluster-runners-table">
-            <CardContent className="px-0">
-              <div
-                className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_1fr_1fr_2fr_120px]"
-                data-testid="organization-cluster-runners-header"
-              >
-                <SortableHeader
-                  label="Runner"
-                  sortKey="name"
-                  activeSortKey={listControls.sortKey}
-                  sortDirection={listControls.sortDirection}
-                  onSort={listControls.handleSort}
-                />
-                <SortableHeader
-                  label="Status"
-                  sortKey="status"
-                  activeSortKey={listControls.sortKey}
-                  sortDirection={listControls.sortDirection}
-                  onSort={listControls.handleSort}
-                />
-                <SortableHeader
-                  label="Scope"
-                  sortKey="scope"
-                  activeSortKey={listControls.sortKey}
-                  sortDirection={listControls.sortDirection}
-                  onSort={listControls.handleSort}
-                />
-                <SortableHeader
-                  label="Labels"
-                  sortKey="labels"
-                  activeSortKey={listControls.sortKey}
-                  sortDirection={listControls.sortDirection}
-                  onSort={listControls.handleSort}
-                />
-                <span className="text-right">Action</span>
-              </div>
-              <div className="divide-y divide-border">
-                {clusterRunners.length === 0 ? (
-                  <div className="px-6 py-6 text-sm text-muted-foreground">
-                    {hasSearch ? 'No results found.' : 'No cluster runners available.'}
-                  </div>
-                ) : (
-                  clusterRunners.map((runner) => (
-                    <div
-                      key={runner.meta?.id ?? runner.name}
-                      className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_1fr_2fr_120px]"
-                      data-testid="organization-cluster-runner-row"
-                    >
-                      <div>
-                        <div className="font-medium" data-testid="organization-cluster-runner-name">
-                          {runner.name}
-                        </div>
-                        <div className="text-xs text-muted-foreground" data-testid="organization-cluster-runner-id">
-                          {runner.meta?.id}
-                        </div>
-                      </div>
-                      <Badge variant="secondary" data-testid="organization-cluster-runner-status">
-                        {formatRunnerStatus(runner.status)}
-                      </Badge>
-                      <Badge variant="outline" data-testid="organization-cluster-runner-scope">
-                        Cluster
-                      </Badge>
-                      <span
-                        className="text-xs text-muted-foreground"
-                        data-testid="organization-cluster-runner-labels"
-                      >
-                        {formatLabelPairs(runner.labels)}
-                      </span>
-                      <div className="text-right">{renderClusterRunnerView(runner.meta?.id)}</div>
-                    </div>
-                  ))
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
+        <RunnerTableSection
+          title="Organization Runners"
+          description="Runners scoped to this organization."
+          listControls={organizationListControls}
+          hasSearch={hasSearch}
+          emptyMessage="No organization runners registered."
+          scopeLabel="Organization"
+          headerAction={enrollAction}
+          renderAction={renderOrgRunnerView}
+          testIds={organizationTestIds}
+        />
+        <RunnerTableSection
+          title="Cluster Runners"
+          description="Shared runners available to this organization."
+          listControls={clusterListControls}
+          hasSearch={hasSearch}
+          emptyMessage="No cluster runners available."
+          scopeLabel="Cluster"
+          renderAction={renderClusterRunnerView}
+          testIds={clusterTestIds}
+        />
       </div>
       <LoadMoreButton
         hasMore={Boolean(runnersQuery.hasNextPage)}

--- a/src/pages/RunnerDetailPage.tsx
+++ b/src/pages/RunnerDetailPage.tsx
@@ -27,9 +27,10 @@ import { DEFAULT_PAGE_SIZE } from '@/lib/pagination';
 import { toast } from 'sonner';
 
 export function RunnerDetailPage() {
-  const { id, runnerId: runnerParam } = useParams();
-  const organizationId = runnerParam ? id ?? '' : '';
-  const runnerId = runnerParam ?? id ?? '';
+  const { id: organizationIdParam, runnerId: runnerIdParam } = useParams();
+  const isOrgContext = Boolean(organizationIdParam);
+  const organizationId = isOrgContext ? organizationIdParam ?? '' : '';
+  const runnerId = runnerIdParam ?? '';
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [editOpen, setEditOpen] = useState(false);
@@ -53,7 +54,6 @@ export function RunnerDetailPage() {
   });
 
   const runner = runnerQuery.data?.runner;
-  const isOrgContext = Boolean(runnerParam);
   const isOrgRunner = Boolean(organizationId) && runner?.organizationId === organizationId;
   const canManageRunner = !isOrgContext || isOrgRunner;
 
@@ -141,8 +141,8 @@ export function RunnerDetailPage() {
   };
 
   const deleteDescription = runner?.organizationId
-    ? `This action permanently removes the runner from organization ${runner.organizationId}.`
-    : 'This action permanently removes the cluster runner.';
+    ? 'This action permanently removes the organization runner. This cannot be undone.'
+    : 'This action permanently removes the cluster runner. This cannot be undone.';
 
   return (
     <div className="space-y-6">

--- a/src/pages/RunnerDetailPage.tsx
+++ b/src/pages/RunnerDetailPage.tsx
@@ -17,6 +17,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useNotifications } from '@/hooks/useNotifications';
 import { formatLabelPairs, formatRunnerStatus } from '@/lib/format';
@@ -25,13 +27,16 @@ import { DEFAULT_PAGE_SIZE } from '@/lib/pagination';
 import { toast } from 'sonner';
 
 export function RunnerDetailPage() {
-  const { id } = useParams();
-  const runnerId = id ?? '';
+  const { id, runnerId: runnerParam } = useParams();
+  const organizationId = runnerParam ? id ?? '' : '';
+  const runnerId = runnerParam ?? id ?? '';
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [labelEntries, setLabelEntries] = useState<LabelEntry[]>([]);
+  const [runnerName, setRunnerName] = useState('');
+  const [runnerNameError, setRunnerNameError] = useState('');
 
   useNotifications({
     events: ['workload.status_changed'],
@@ -48,6 +53,9 @@ export function RunnerDetailPage() {
   });
 
   const runner = runnerQuery.data?.runner;
+  const isOrgContext = Boolean(runnerParam);
+  const isOrgRunner = Boolean(organizationId) && runner?.organizationId === organizationId;
+  const canManageRunner = !isOrgContext || isOrgRunner;
 
   useDocumentTitle(runner?.name ?? 'Runner');
 
@@ -70,7 +78,8 @@ export function RunnerDetailPage() {
   const workloads = workloadsQuery.data?.pages.flatMap((page) => page.workloads) ?? [];
 
   const updateRunnerMutation = useMutation({
-    mutationFn: (labels: Record<string, string>) => runnersClient.updateRunner({ id: runnerId, labels }),
+    mutationFn: (payload: { name: string; labels: Record<string, string> }) =>
+      runnersClient.updateRunner({ id: runnerId, ...payload }),
     onSuccess: () => {
       toast.success('Runner updated.');
       void queryClient.invalidateQueries({ queryKey: ['runners', runnerId] });
@@ -78,7 +87,7 @@ export function RunnerDetailPage() {
       if (runner?.organizationId) {
         void queryClient.invalidateQueries({ queryKey: ['runners', runner.organizationId, 'list'] });
       }
-      setEditOpen(false);
+      handleEditOpenChange(false);
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : 'Failed to update runner.');
@@ -102,25 +111,43 @@ export function RunnerDetailPage() {
     },
   });
 
+  const resetEditState = () => {
+    setLabelEntries([]);
+    setRunnerName('');
+    setRunnerNameError('');
+  };
+
   const handleEditOpenChange = (open: boolean) => {
     if (open) {
       const entries = labelsToEntries(runner?.labels ?? {});
       setLabelEntries(entries.length ? entries : [createLabelEntry()]);
+      setRunnerName(runner?.name ?? '');
+      setRunnerNameError('');
       setEditOpen(true);
       return;
     }
     setEditOpen(false);
-    setLabelEntries([]);
+    resetEditState();
   };
 
-  const handleSaveLabels = () => {
-    updateRunnerMutation.mutate(entriesToLabels(labelEntries));
+  const handleSaveRunner = () => {
+    const trimmedName = runnerName.trim();
+    if (!trimmedName) {
+      setRunnerNameError('Runner name is required.');
+      return;
+    }
+    setRunnerNameError('');
+    updateRunnerMutation.mutate({ name: trimmedName, labels: entriesToLabels(labelEntries) });
   };
+
+  const deleteDescription = runner?.organizationId
+    ? `This action permanently removes the runner from organization ${runner.organizationId}.`
+    : 'This action permanently removes the cluster runner.';
 
   return (
     <div className="space-y-6">
       <div className="flex flex-wrap items-center justify-end gap-3">
-        {runner ? (
+        {runner && canManageRunner ? (
           <div className="flex flex-wrap items-center gap-2" data-testid="runner-actions">
             <Button
               variant="outline"
@@ -128,7 +155,7 @@ export function RunnerDetailPage() {
               onClick={() => handleEditOpenChange(true)}
               data-testid="runner-edit-labels"
             >
-              Edit labels
+              Edit runner
             </Button>
             <Button
               variant="destructive"
@@ -193,12 +220,36 @@ export function RunnerDetailPage() {
       <Dialog open={editOpen} onOpenChange={handleEditOpenChange}>
         <DialogContent data-testid="runner-edit-dialog">
           <DialogHeader>
-            <DialogTitle data-testid="runner-edit-title">Edit runner labels</DialogTitle>
+            <DialogTitle data-testid="runner-edit-title">Edit runner</DialogTitle>
             <DialogDescription data-testid="runner-edit-description">
-              Update label key-value pairs for this runner.
+              Update the runner name and labels.
             </DialogDescription>
           </DialogHeader>
-          <LabelsEditor value={labelEntries} onChange={setLabelEntries} testIdPrefix="runner-edit" />
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="runner-edit-name">Runner Name</Label>
+              <Input
+                id="runner-edit-name"
+                value={runnerName}
+                onChange={(event) => {
+                  setRunnerName(event.target.value);
+                  if (runnerNameError) setRunnerNameError('');
+                }}
+                disabled={updateRunnerMutation.isPending}
+                data-testid="runner-edit-name"
+              />
+              {runnerNameError ? <p className="text-sm text-destructive">{runnerNameError}</p> : null}
+            </div>
+            <div className="space-y-2">
+              <div className="text-sm font-medium text-foreground">Labels</div>
+              <LabelsEditor
+                value={labelEntries}
+                onChange={setLabelEntries}
+                disabled={updateRunnerMutation.isPending}
+                testIdPrefix="runner-edit"
+              />
+            </div>
+          </div>
           <DialogFooter>
             <DialogClose asChild>
               <Button variant="outline" size="sm" data-testid="runner-edit-cancel">
@@ -207,11 +258,11 @@ export function RunnerDetailPage() {
             </DialogClose>
             <Button
               size="sm"
-              onClick={handleSaveLabels}
+              onClick={handleSaveRunner}
               disabled={updateRunnerMutation.isPending}
               data-testid="runner-edit-submit"
             >
-              {updateRunnerMutation.isPending ? 'Saving...' : 'Save labels'}
+              {updateRunnerMutation.isPending ? 'Saving...' : 'Save runner'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -220,7 +271,7 @@ export function RunnerDetailPage() {
         open={deleteOpen}
         onOpenChange={setDeleteOpen}
         title="Delete runner"
-        description="This action permanently removes the runner."
+        description={deleteDescription}
         confirmLabel="Delete runner"
         variant="danger"
         onConfirm={() => deleteRunnerMutation.mutate()}

--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -209,6 +209,11 @@ type ListRunnersResponseWire = {
   runners?: RunnerWire[];
 };
 
+type RegisterRunnerResponseWire = {
+  runner?: RunnerWire;
+  serviceToken?: string;
+};
+
 type GetRunnerResponseWire = {
   runner?: RunnerWire;
 };
@@ -981,6 +986,35 @@ export async function listRunners(page: Page): Promise<RunnerWire[]> {
     pageToken: '',
   });
   return response.runners ?? [];
+}
+
+export async function registerRunner(
+  page: Page,
+  opts: {
+    name: string;
+    labels?: Record<string, string>;
+    organizationId?: string;
+    capabilities?: string[];
+  },
+): Promise<RunnerWire> {
+  const payload: Record<string, unknown> = {
+    name: opts.name,
+    labels: opts.labels ?? {},
+    capabilities: opts.capabilities ?? [],
+  };
+  if (opts.organizationId) {
+    payload.organizationId = opts.organizationId;
+  }
+  const response = await postConnect<RegisterRunnerResponseWire>(
+    page,
+    RUNNERS_GATEWAY_PATH,
+    'RegisterRunner',
+    payload,
+  );
+  if (!response.runner?.meta?.id) {
+    throw new Error('RegisterRunner response missing runner id.');
+  }
+  return response.runner;
 }
 
 export async function getRunner(page: Page, runnerId: string): Promise<RunnerWire> {

--- a/test/e2e/mock-server.mjs
+++ b/test/e2e/mock-server.mjs
@@ -655,11 +655,25 @@ function handleSecretsGateway(method, body, res) {
 
 function handleRunnersGateway(method, body, res) {
   switch (method) {
+    case 'RegisterRunner': {
+      const id = randomUUID();
+      const runner = {
+        id,
+        name: body.name ?? `runner-${id}`,
+        labels: body.labels ?? {},
+        status: 'RUNNER_STATUS_ENROLLED',
+        identityId: `runner-identity-${id}`,
+        organizationId: body.organizationId ?? '',
+        openzitiServiceName: `runner-${id}`,
+      };
+      runners.set(id, runner);
+      return sendJson(res, 200, { runner: mapRunner(runner), serviceToken: `token-${id}` });
+    }
     case 'ListRunners': {
       const orgId = body.organizationId ?? '';
       const result = Array.from(runners.values()).filter((runner) => {
         if (!orgId) return !runner.organizationId;
-        return runner.organizationId === orgId;
+        return runner.organizationId === orgId || !runner.organizationId;
       });
       return sendJson(res, 200, { runners: result.map(mapRunner), nextPageToken: '' });
     }

--- a/test/e2e/runners.spec.ts
+++ b/test/e2e/runners.spec.ts
@@ -1,12 +1,59 @@
 import { argosScreenshot } from '@argos-ci/playwright';
 import { test, expect } from './fixtures';
-import { listRunners } from './console-api';
+import { createOrganization, listRunners, registerRunner, setSelectedOrganization } from './console-api';
 
 test('lists cluster runners', async ({ page }) => {
   await page.goto('/runners');
   await expect(page.getByTestId('runners-table')).toBeVisible({ timeout: 15000 });
   await expect(page.getByTestId('runners-row').first()).toBeVisible({ timeout: 15000 });
   await argosScreenshot(page, 'runners-list');
+});
+
+test('lists organization and cluster runners', async ({ page }) => {
+  const orgId = await createOrganization(page, `e2e-org-runners-${Date.now()}`);
+  await setSelectedOrganization(page, orgId);
+  const orgRunnerName = `e2e-org-runner-${Date.now()}`;
+  const clusterRunnerName = `e2e-cluster-runner-${Date.now()}`;
+
+  await registerRunner(page, {
+    name: orgRunnerName,
+    organizationId: orgId,
+    labels: { scope: 'organization' },
+  });
+  await registerRunner(page, {
+    name: clusterRunnerName,
+    labels: { scope: 'cluster' },
+  });
+
+  await page.goto(`/organizations/${orgId}/runners`);
+  await expect(page.getByTestId('organization-runners-table')).toBeVisible({ timeout: 15000 });
+  await expect(
+    page.getByTestId('organization-runner-row').filter({ hasText: orgRunnerName }),
+  ).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId('organization-cluster-runners-table')).toBeVisible({ timeout: 15000 });
+  await expect(
+    page.getByTestId('organization-cluster-runner-row').filter({ hasText: clusterRunnerName }),
+  ).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'organization-runners-list');
+});
+
+test('organization runner detail shows metadata', async ({ page }) => {
+  const orgId = await createOrganization(page, `e2e-org-runner-detail-${Date.now()}`);
+  await setSelectedOrganization(page, orgId);
+  const orgRunnerName = `e2e-org-runner-detail-${Date.now()}`;
+  const runner = await registerRunner(page, {
+    name: orgRunnerName,
+    organizationId: orgId,
+    labels: { scope: 'organization' },
+  });
+  const runnerId = runner.meta?.id;
+  if (!runnerId) {
+    throw new Error('RegisterRunner response missing runner id for org detail test.');
+  }
+
+  await page.goto(`/organizations/${orgId}/runners/${runnerId}`);
+  await expect(page.getByTestId('runner-details-card')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'organization-runner-detail');
 });
 
 test('runner detail shows metadata', async ({ page }) => {


### PR DESCRIPTION
## Summary
- split organization runners into org/cluster sections with scope badges and view actions
- add organization runner detail routing with org-context edit/delete gating
- expand runner edit dialog to update name and labels with scope-aware delete copy

## Testing
- npm run generate
- npm run lint
- npm run typecheck
- npm test
- npm run build
- VITE_OIDC_AUTHORITY=http://127.0.0.1:5000 VITE_OIDC_CLIENT_ID=console-app VITE_OIDC_SCOPE='openid profile email' npm run build
- set -e
  npm run preview -- --port 4173 --strictPort > /tmp/preview.log 2>&1 &
  preview_pid=$!
  MOCK_SERVER_PORT=5000 MOCK_PROXY_TARGET=http://127.0.0.1:4173 MOCK_METERING_PORT=50051 node test/e2e/mock-server.mjs > /tmp/mock.log 2>&1 &
  mock_pid=$!
  cleanup() { kill "$preview_pid" "$mock_pid" 2>/dev/null || true; }
  trap cleanup EXIT
  for i in $(seq 1 30); do
    if curl -sf http://127.0.0.1:5000 >/dev/null; then
      break
    fi
    sleep 1
  done
  E2E_BASE_URL=http://127.0.0.1:5000 E2E_OIDC_AUTHORITY=http://127.0.0.1:5000 E2E_OIDC_CLIENT_ID=console-app E2E_OIDC_SCOPE='openid profile email' METERING_GRPC_URL=http://127.0.0.1:50051 npm run test:e2e

Closes #65