### PR TITLE
feat(console-app): add org threads views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,8 @@ import { OrganizationUsageTab } from '@/pages/OrganizationUsageTab';
 import { OrganizationImagePullSecretsTab } from '@/pages/OrganizationImagePullSecretsTab';
 import { OrganizationSecretProvidersTab } from '@/pages/OrganizationSecretProvidersTab';
 import { OrganizationSecretsTab } from '@/pages/OrganizationSecretsTab';
+import { OrganizationThreadDetailPage } from '@/pages/OrganizationThreadDetailPage';
+import { OrganizationThreadsTab } from '@/pages/OrganizationThreadsTab';
 import { OrganizationVolumesTab } from '@/pages/OrganizationVolumesTab';
 import { UsersListPage } from '@/pages/UsersListPage';
 import { UserDetailPage } from '@/pages/UserDetailPage';
@@ -65,6 +67,8 @@ export default function App() {
           <Route path="runners/:runnerId" element={<RunnerDetailPage />} />
           <Route path="apps" element={<OrganizationAppsTab />} />
           <Route path="apps/:appId" element={<AppDetailPage />} />
+          <Route path="threads" element={<OrganizationThreadsTab />} />
+          <Route path="threads/:threadId" element={<OrganizationThreadDetailPage />} />
           <Route path="monitoring" element={<OrganizationMonitoringTab />} />
           <Route path="usage" element={<OrganizationUsageTab />} />
         </Route>

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,12 +4,14 @@ import { authInterceptor } from '@/auth';
 import { config } from '@/config';
 import { AgentsGateway } from '@/gen/agynio/api/gateway/v1/agents_pb';
 import { AppsGateway } from '@/gen/agynio/api/gateway/v1/apps_pb';
+import { FilesGateway } from '@/gen/agynio/api/gateway/v1/files_pb';
 import { LLMGateway } from '@/gen/agynio/api/gateway/v1/llm_pb';
 import { MeteringGateway } from '@/gen/agynio/api/gateway/v1/metering_pb';
 import { NotificationsGateway } from '@/gen/agynio/api/gateway/v1/notifications_pb';
 import { OrganizationsGateway } from '@/gen/agynio/api/gateway/v1/organizations_pb';
 import { RunnersGateway } from '@/gen/agynio/api/gateway/v1/runners_pb';
 import { SecretsGateway } from '@/gen/agynio/api/gateway/v1/secrets_pb';
+import { ThreadsGateway } from '@/gen/agynio/api/gateway/v1/threads_pb';
 import { UsersGateway } from '@/gen/agynio/api/gateway/v1/users_pb';
 
 const transport = createConnectTransport({
@@ -26,3 +28,5 @@ export const organizationsClient = createClient(OrganizationsGateway, transport)
 export const runnersClient = createClient(RunnersGateway, transport);
 export const secretsClient = createClient(SecretsGateway, transport);
 export const notificationsClient = createClient(NotificationsGateway, transport);
+export const threadsClient = createClient(ThreadsGateway, transport);
+export const filesClient = createClient(FilesGateway, transport);

--- a/src/hooks/useIdentityHandles.ts
+++ b/src/hooks/useIdentityHandles.ts
@@ -1,0 +1,114 @@
+import { useMemo } from 'react';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { agentsClient, appsClient, usersClient } from '@/api/client';
+import { EMPTY_PLACEHOLDER } from '@/lib/format';
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof ConnectError && error.code === Code.NotFound;
+}
+
+export function useIdentityHandles(identityIds: string[]) {
+  const uniqueIds = useMemo(
+    () => Array.from(new Set(identityIds.filter((identityId) => identityId))),
+    [identityIds],
+  );
+
+  const usersQuery = useQuery({
+    queryKey: ['users', 'batch', uniqueIds.join(',')],
+    queryFn: () => usersClient.batchGetUsers({ identityIds: uniqueIds }),
+    enabled: uniqueIds.length > 0,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const userMap = useMemo(() => {
+    const users = usersQuery.data?.users ?? [];
+    return new Map(
+      users.flatMap((user) => {
+        const userId = user.meta?.id;
+        return userId ? ([[userId, user]] as const) : [];
+      }),
+    );
+  }, [usersQuery.data?.users]);
+
+  const unresolvedIds = useMemo(
+    () => uniqueIds.filter((identityId) => !userMap.has(identityId)),
+    [uniqueIds, userMap],
+  );
+
+  const agentQueries = useQueries({
+    queries: unresolvedIds.map((identityId) => ({
+      queryKey: ['agents', 'identity', identityId],
+      queryFn: async () => {
+        try {
+          return await agentsClient.getAgent({ id: identityId });
+        } catch (error) {
+          if (isNotFound(error)) return null;
+          throw error;
+        }
+      },
+      enabled: Boolean(identityId),
+      retry: false,
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const agentMap = useMemo(
+    () =>
+      new Map(
+        agentQueries.flatMap((query, index) => {
+          const identityId = unresolvedIds[index];
+          const agent = query.data?.agent;
+          return identityId && agent ? ([[identityId, agent]] as const) : [];
+        }),
+      ),
+    [agentQueries, unresolvedIds],
+  );
+
+  const appProfileQueries = useQueries({
+    queries: unresolvedIds.map((identityId) => ({
+      queryKey: ['apps', 'profile', identityId],
+      queryFn: async () => {
+        try {
+          return await appsClient.getAppProfile({ identityId });
+        } catch (error) {
+          if (isNotFound(error)) return null;
+          throw error;
+        }
+      },
+      enabled: Boolean(identityId),
+      retry: false,
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const appProfileMap = useMemo(
+    () =>
+      new Map(
+        appProfileQueries.flatMap((query, index) => {
+          const identityId = unresolvedIds[index];
+          const profile = query.data?.profile;
+          return identityId && profile ? ([[identityId, profile]] as const) : [];
+        }),
+      ),
+    [appProfileQueries, unresolvedIds],
+  );
+
+  const formatHandle = useMemo(() => {
+    return (identityId?: string | null) => {
+      if (!identityId) return EMPTY_PLACEHOLDER;
+      const user = userMap.get(identityId);
+      if (user) return `@${user.nickname || user.name || user.email || identityId}`;
+      const agent = agentMap.get(identityId);
+      if (agent) return `@${agent.nickname || agent.name || identityId}`;
+      const appProfile = appProfileMap.get(identityId);
+      if (appProfile) return `@${appProfile.name || appProfile.slug || identityId}`;
+      return `@${identityId}`;
+    };
+  }, [agentMap, appProfileMap, userMap]);
+
+  return { formatHandle };
+}

--- a/src/hooks/useIdentityHandles.ts
+++ b/src/hooks/useIdentityHandles.ts
@@ -32,10 +32,10 @@ export function useIdentityHandles(identityIds: string[]) {
     );
   }, [usersQuery.data?.users]);
 
-  const unresolvedIds = useMemo(
-    () => uniqueIds.filter((identityId) => !userMap.has(identityId)),
-    [uniqueIds, userMap],
-  );
+  const unresolvedIds = useMemo(() => {
+    if (usersQuery.isPending) return [];
+    return uniqueIds.filter((identityId) => !userMap.has(identityId));
+  }, [uniqueIds, userMap, usersQuery.isPending]);
 
   const agentQueries = useQueries({
     queries: unresolvedIds.map((identityId) => ({
@@ -48,7 +48,7 @@ export function useIdentityHandles(identityIds: string[]) {
           throw error;
         }
       },
-      enabled: Boolean(identityId),
+      enabled: !usersQuery.isPending && Boolean(identityId),
       retry: false,
       staleTime: 60_000,
       refetchOnWindowFocus: false,
@@ -78,7 +78,7 @@ export function useIdentityHandles(identityIds: string[]) {
           throw error;
         }
       },
-      enabled: Boolean(identityId),
+      enabled: !usersQuery.isPending && Boolean(identityId),
       retry: false,
       staleTime: 60_000,
       refetchOnWindowFocus: false,

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -11,6 +11,7 @@ import {
   HomeIcon,
   KeyIcon,
   LineChartIcon,
+  MessageSquareIcon,
   MonitorSmartphoneIcon,
   SettingsIcon,
   ShieldIcon,
@@ -332,6 +333,14 @@ export function AppLayout() {
               >
                 <BoxesIcon className="h-4 w-4" />
                 Apps
+              </NavLink>
+              <NavLink
+                to={organizationRoute('/threads')}
+                className={navLinkClass}
+                data-testid="nav-organization-threads"
+              >
+                <MessageSquareIcon className="h-4 w-4" />
+                Threads
               </NavLink>
               <NavLink
                 to={organizationRoute('/members')}

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -335,20 +335,20 @@ export function AppLayout() {
                 Apps
               </NavLink>
               <NavLink
-                to={organizationRoute('/threads')}
-                className={navLinkClass}
-                data-testid="nav-organization-threads"
-              >
-                <MessageSquareIcon className="h-4 w-4" />
-                Threads
-              </NavLink>
-              <NavLink
                 to={organizationRoute('/members')}
                 className={navLinkClass}
                 data-testid="nav-organization-members"
               >
                 <UsersIcon className="h-4 w-4" />
                 Members
+              </NavLink>
+              <NavLink
+                to={organizationRoute('/threads')}
+                className={navLinkClass}
+                data-testid="nav-organization-threads"
+              >
+                <MessageSquareIcon className="h-4 w-4" />
+                Threads
               </NavLink>
               <NavLink
                 to={organizationRoute('/monitoring')}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -5,6 +5,7 @@ import { AuthMethod } from '@/gen/agynio/api/llm/v1/llm_pb';
 import { MembershipRole, MembershipStatus } from '@/gen/agynio/api/organizations/v1/organizations_pb';
 import { ContainerStatus, RunnerStatus, WorkloadStatus } from '@/gen/agynio/api/runners/v1/runners_pb';
 import { SecretProviderType } from '@/gen/agynio/api/secrets/v1/secrets_pb';
+import { ThreadStatus } from '@/gen/agynio/api/threads/v1/threads_pb';
 import { ClusterRole, DeviceStatus } from '@/gen/agynio/api/users/v1/users_pb';
 
 export const EMPTY_PLACEHOLDER = '—';
@@ -138,5 +139,12 @@ export function formatMembershipStatus(status?: MembershipStatus): string {
   if (status === MembershipStatus.ACTIVE) return 'Active';
   if (status === MembershipStatus.PENDING) return 'Pending';
   if (status === MembershipStatus.UNSPECIFIED) return 'Unspecified';
+  return 'Unspecified';
+}
+
+export function formatThreadStatus(status?: ThreadStatus): string {
+  if (status === ThreadStatus.ACTIVE) return 'Active';
+  if (status === ThreadStatus.ARCHIVED) return 'Archived';
+  if (status === ThreadStatus.UNSPECIFIED) return 'Unspecified';
   return 'Unspecified';
 }

--- a/src/pages/OrganizationThreadDetailPage.tsx
+++ b/src/pages/OrganizationThreadDetailPage.tsx
@@ -1,8 +1,8 @@
-import { useMemo } from 'react';
+import { useMemo, useState, type MouseEvent } from 'react';
 import { NavLink, useParams } from 'react-router-dom';
 import { create } from '@bufbuild/protobuf';
 import { DurationSchema } from '@bufbuild/protobuf/wkt';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
 import { filesClient, threadsClient } from '@/api/client';
 import { LoadMoreButton } from '@/components/LoadMoreButton';
 import { Badge } from '@/components/ui/badge';
@@ -30,40 +30,58 @@ type AttachmentLinkProps = {
 };
 
 function AttachmentLink({ fileId }: AttachmentLinkProps) {
-  const downloadQuery = useQuery({
-    queryKey: ['files', fileId, 'download'],
-    queryFn: async () => {
-      const [metadata, download] = await Promise.all([
-        filesClient.getFileMetadata({ fileId }),
-        filesClient.getDownloadUrl({ fileId, expiry: attachmentExpiry }),
-      ]);
-      return { file: metadata.file, url: download.url };
-    },
+  const [hasRequested, setHasRequested] = useState(false);
+
+  const metadataQuery = useQuery({
+    queryKey: ['files', fileId, 'metadata'],
+    queryFn: () => filesClient.getFileMetadata({ fileId }),
     enabled: Boolean(fileId),
     staleTime: 60_000,
     refetchOnWindowFocus: false,
   });
 
-  if (downloadQuery.isPending) {
-    return <span className="text-xs text-muted-foreground">Loading attachment...</span>;
-  }
+  const downloadMutation = useMutation({
+    mutationFn: async () => {
+      const download = await filesClient.getDownloadUrl({ fileId, expiry: attachmentExpiry });
+      if (!download.url) {
+        throw new Error('Download URL missing.');
+      }
+      return download.url;
+    },
+  });
 
-  if (downloadQuery.isError || !downloadQuery.data?.url) {
+  const label = metadataQuery.data?.file?.filename || fileId;
+  const showUnavailable = metadataQuery.isError || (hasRequested && downloadMutation.isError);
+
+  if (showUnavailable) {
     return <span className="text-xs text-muted-foreground">Attachment unavailable.</span>;
   }
 
-  const label = downloadQuery.data.file?.filename || fileId;
+  if (downloadMutation.isPending) {
+    return <span className="text-xs text-muted-foreground">Generating download link...</span>;
+  }
+
+  const handleDownload = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    if (!fileId || downloadMutation.isPending) return;
+    setHasRequested(true);
+    try {
+      const url = await downloadMutation.mutateAsync();
+      window.open(url, '_blank', 'noopener,noreferrer');
+    } catch {
+      // Errors are surfaced via the mutation state.
+    }
+  };
 
   return (
-    <a
-      href={downloadQuery.data.url}
+    <button
+      type="button"
+      onClick={handleDownload}
       className="text-sm text-primary underline underline-offset-4"
-      target="_blank"
-      rel="noreferrer"
       data-testid="thread-attachment-link"
     >
       Download {label}
-    </a>
+    </button>
   );
 }
 
@@ -119,6 +137,8 @@ export function OrganizationThreadDetailPage() {
   useDocumentTitle(threadTitle);
 
   const messageCount = thread?.messageCount ?? 0;
+  const isThreadLoading = threadQuery.isPending;
+  const isThreadError = threadQuery.isError;
 
   return (
     <div className="space-y-6">
@@ -170,34 +190,42 @@ export function OrganizationThreadDetailPage() {
           <CardTitle>Participants</CardTitle>
         </CardHeader>
         <CardContent>
-          {participants.length === 0 ? (
-            <div className="text-sm text-muted-foreground">No participants found.</div>
-          ) : (
-            <div className="divide-y divide-border">
-              {participants.map((participant) => (
-                <div
-                  key={participant.id}
-                  className="flex flex-wrap items-center justify-between gap-3 py-3"
-                  data-testid="thread-participant-row"
-                >
-                  <div>
-                    <div className="text-sm font-medium text-foreground">{formatHandle(participant.id)}</div>
-                    <div className="text-xs text-muted-foreground">{participant.id}</div>
+          {isThreadLoading ? (
+            <div className="text-sm text-muted-foreground">Loading participants...</div>
+          ) : null}
+          {isThreadError ? (
+            <div className="text-sm text-muted-foreground">Unable to load participants.</div>
+          ) : null}
+          {!isThreadLoading && !isThreadError ? (
+            participants.length === 0 ? (
+              <div className="text-sm text-muted-foreground">No participants found.</div>
+            ) : (
+              <div className="divide-y divide-border">
+                {participants.map((participant) => (
+                  <div
+                    key={participant.id}
+                    className="flex flex-wrap items-center justify-between gap-3 py-3"
+                    data-testid="thread-participant-row"
+                  >
+                    <div>
+                      <div className="text-sm font-medium text-foreground">{formatHandle(participant.id)}</div>
+                      <div className="text-xs text-muted-foreground">{participant.id}</div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {participant.passive ? (
+                        <Badge variant="outline" className="text-xs text-muted-foreground">
+                          Passive
+                        </Badge>
+                      ) : null}
+                      <span className="text-xs text-muted-foreground">
+                        Joined {formatDateOnly(participant.joinedAt)}
+                      </span>
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    {participant.passive ? (
-                      <Badge variant="outline" className="text-xs text-muted-foreground">
-                        Passive
-                      </Badge>
-                    ) : null}
-                    <span className="text-xs text-muted-foreground">
-                      Joined {formatDateOnly(participant.joinedAt)}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+                ))}
+              </div>
+            )
+          ) : null}
         </CardContent>
       </Card>
       <Card className="border-border" data-testid="thread-messages-card">
@@ -205,45 +233,55 @@ export function OrganizationThreadDetailPage() {
           <CardTitle>Messages</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          {messagesQuery.isPending ? (
+          {isThreadLoading ? (
             <div className="text-sm text-muted-foreground">Loading messages...</div>
           ) : null}
-          {messagesQuery.isError ? (
-            <div className="text-sm text-muted-foreground">Failed to load messages.</div>
+          {isThreadError ? (
+            <div className="text-sm text-muted-foreground">Unable to load messages.</div>
           ) : null}
-          {messages.length === 0 && !messagesQuery.isPending ? (
-            <div className="text-sm text-muted-foreground">No messages yet.</div>
-          ) : null}
-          {messages.map((message) => (
-            <div
-              key={message.id}
-              className="rounded-lg border border-border p-4"
-              data-testid="thread-message-row"
-            >
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="text-sm font-semibold text-foreground">{formatHandle(message.senderId)}</div>
-                <div className="text-xs text-muted-foreground">{formatTimestamp(message.createdAt)}</div>
-              </div>
-              <div className="mt-2 text-sm text-foreground whitespace-pre-wrap">
-                {message.body || EMPTY_PLACEHOLDER}
-              </div>
-              {message.fileIds.length > 0 ? (
-                <div className="mt-3 space-y-2">
-                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Attachments</div>
-                  <div className="space-y-1">
-                    {message.fileIds.map((fileId) => (
-                      <AttachmentLink key={fileId} fileId={fileId} />
-                    ))}
-                  </div>
-                </div>
+          {!isThreadLoading && !isThreadError ? (
+            <>
+              {messagesQuery.isPending ? (
+                <div className="text-sm text-muted-foreground">Loading messages...</div>
               ) : null}
-            </div>
-          ))}
-          <LoadMoreButton
-            hasMore={messagesQuery.hasNextPage}
-            isLoading={messagesQuery.isFetchingNextPage}
-            onClick={() => messagesQuery.fetchNextPage()}
-          />
+              {messagesQuery.isError ? (
+                <div className="text-sm text-muted-foreground">Failed to load messages.</div>
+              ) : null}
+              {messages.length === 0 && !messagesQuery.isPending && !messagesQuery.isError ? (
+                <div className="text-sm text-muted-foreground">No messages yet.</div>
+              ) : null}
+              {messages.map((message) => (
+                <div
+                  key={message.id}
+                  className="rounded-lg border border-border p-4"
+                  data-testid="thread-message-row"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="text-sm font-semibold text-foreground">{formatHandle(message.senderId)}</div>
+                    <div className="text-xs text-muted-foreground">{formatTimestamp(message.createdAt)}</div>
+                  </div>
+                  <div className="mt-2 text-sm text-foreground whitespace-pre-wrap">
+                    {message.body || EMPTY_PLACEHOLDER}
+                  </div>
+                  {message.fileIds.length > 0 ? (
+                    <div className="mt-3 space-y-2">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">Attachments</div>
+                      <div className="space-y-1">
+                        {message.fileIds.map((fileId) => (
+                          <AttachmentLink key={fileId} fileId={fileId} />
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+              <LoadMoreButton
+                hasMore={messagesQuery.hasNextPage}
+                isLoading={messagesQuery.isFetchingNextPage}
+                onClick={() => messagesQuery.fetchNextPage()}
+              />
+            </>
+          ) : null}
         </CardContent>
       </Card>
     </div>

--- a/src/pages/OrganizationThreadDetailPage.tsx
+++ b/src/pages/OrganizationThreadDetailPage.tsx
@@ -1,0 +1,348 @@
+import { useMemo } from 'react';
+import { NavLink, useParams } from 'react-router-dom';
+import { create } from '@bufbuild/protobuf';
+import { DurationSchema } from '@bufbuild/protobuf/wkt';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { useInfiniteQuery, useQueries, useQuery } from '@tanstack/react-query';
+import { agentsClient, appsClient, filesClient, threadsClient, usersClient } from '@/api/client';
+import { LoadMoreButton } from '@/components/LoadMoreButton';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { MessageOrder } from '@/gen/agynio/api/threads/v1/threads_pb';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import {
+  EMPTY_PLACEHOLDER,
+  formatDateOnly,
+  formatThreadStatus,
+  formatTimestamp,
+  truncate,
+} from '@/lib/format';
+import { DEFAULT_PAGE_SIZE } from '@/lib/pagination';
+
+const attachmentExpiry = create(DurationSchema, {
+  seconds: BigInt(900),
+  nanos: 0,
+});
+
+type AttachmentLinkProps = {
+  fileId: string;
+};
+
+function AttachmentLink({ fileId }: AttachmentLinkProps) {
+  const downloadQuery = useQuery({
+    queryKey: ['files', fileId, 'download'],
+    queryFn: async () => {
+      const [metadata, download] = await Promise.all([
+        filesClient.getFileMetadata({ fileId }),
+        filesClient.getDownloadUrl({ fileId, expiry: attachmentExpiry }),
+      ]);
+      return { file: metadata.file, url: download.url };
+    },
+    enabled: Boolean(fileId),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  if (downloadQuery.isPending) {
+    return <span className="text-xs text-muted-foreground">Loading attachment...</span>;
+  }
+
+  if (downloadQuery.isError || !downloadQuery.data?.url) {
+    return <span className="text-xs text-muted-foreground">Attachment unavailable.</span>;
+  }
+
+  const label = downloadQuery.data.file?.filename || fileId;
+
+  return (
+    <a
+      href={downloadQuery.data.url}
+      className="text-sm text-primary underline underline-offset-4"
+      target="_blank"
+      rel="noreferrer"
+      data-testid="thread-attachment-link"
+    >
+      Download {label}
+    </a>
+  );
+}
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof ConnectError && error.code === Code.NotFound;
+}
+
+export function OrganizationThreadDetailPage() {
+  const { id, threadId } = useParams();
+  const organizationId = id ?? '';
+  const resolvedThreadId = threadId ?? '';
+
+  const threadQuery = useQuery({
+    queryKey: ['threads', resolvedThreadId, 'detail'],
+    queryFn: () => threadsClient.getThread({ threadId: resolvedThreadId }),
+    enabled: Boolean(resolvedThreadId),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const messagesQuery = useInfiniteQuery({
+    queryKey: ['threads', resolvedThreadId, 'messages'],
+    queryFn: ({ pageParam }) =>
+      threadsClient.getMessages({
+        threadId: resolvedThreadId,
+        pageSize: DEFAULT_PAGE_SIZE,
+        pageToken: pageParam,
+        order: MessageOrder.NEWEST_FIRST,
+      }),
+    initialPageParam: '',
+    getNextPageParam: (lastPage) => lastPage.nextPageToken || undefined,
+    enabled: Boolean(resolvedThreadId),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const thread = threadQuery.data?.thread;
+  const messages = useMemo(
+    () => messagesQuery.data?.pages.flatMap((page) => page.messages) ?? [],
+    [messagesQuery.data?.pages],
+  );
+  const participants = useMemo(() => thread?.participants ?? [], [thread?.participants]);
+
+  const identityIds = useMemo(() => {
+    const ids = new Set<string>();
+    participants.forEach((participant) => {
+      if (participant.id) ids.add(participant.id);
+    });
+    messages.forEach((message) => {
+      if (message.senderId) ids.add(message.senderId);
+    });
+    return Array.from(ids);
+  }, [messages, participants]);
+
+  const usersQuery = useQuery({
+    queryKey: ['users', 'batch', identityIds.join(',')],
+    queryFn: () => usersClient.batchGetUsers({ identityIds }),
+    enabled: identityIds.length > 0,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const userMap = useMemo(() => {
+    const users = usersQuery.data?.users ?? [];
+    return new Map(
+      users.flatMap((user) => {
+        const userId = user.meta?.id;
+        return userId ? ([[userId, user]] as const) : [];
+      }),
+    );
+  }, [usersQuery.data?.users]);
+
+  const unresolvedIds = useMemo(
+    () => identityIds.filter((identityId) => !userMap.has(identityId)),
+    [identityIds, userMap],
+  );
+
+  const agentQueries = useQueries({
+    queries: unresolvedIds.map((identityId) => ({
+      queryKey: ['agents', 'identity', identityId],
+      queryFn: async () => {
+        try {
+          return await agentsClient.getAgent({ id: identityId });
+        } catch (error) {
+          if (isNotFound(error)) return null;
+          throw error;
+        }
+      },
+      enabled: Boolean(identityId),
+      retry: false,
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const agentMap = useMemo(
+    () =>
+      new Map(
+        agentQueries.flatMap((query, index) => {
+          const identityId = unresolvedIds[index];
+          const agent = query.data?.agent;
+          return identityId && agent ? ([[identityId, agent]] as const) : [];
+        }),
+      ),
+    [agentQueries, unresolvedIds],
+  );
+
+  const appProfileQueries = useQueries({
+    queries: unresolvedIds.map((identityId) => ({
+      queryKey: ['apps', 'profile', identityId],
+      queryFn: async () => {
+        try {
+          return await appsClient.getAppProfile({ identityId });
+        } catch (error) {
+          if (isNotFound(error)) return null;
+          throw error;
+        }
+      },
+      enabled: Boolean(identityId),
+      retry: false,
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const appProfileMap = useMemo(
+    () =>
+      new Map(
+        appProfileQueries.flatMap((query, index) => {
+          const identityId = unresolvedIds[index];
+          const profile = query.data?.profile;
+          return identityId && profile ? ([[identityId, profile]] as const) : [];
+        }),
+      ),
+    [appProfileQueries, unresolvedIds],
+  );
+
+  const formatHandle = (identityId?: string | null) => {
+    if (!identityId) return EMPTY_PLACEHOLDER;
+    const user = userMap.get(identityId);
+    if (user) return `@${user.nickname || user.name || user.email || identityId}`;
+    const agent = agentMap.get(identityId);
+    if (agent) return `@${agent.nickname || agent.name || identityId}`;
+    const appProfile = appProfileMap.get(identityId);
+    if (appProfile) return `@${appProfile.name || appProfile.slug || identityId}`;
+    return `@${identityId}`;
+  };
+
+  const threadTitle = thread?.id ? `Thread ${truncate(thread.id, 12)}` : 'Thread';
+  useDocumentTitle(threadTitle);
+
+  const messageCount = thread?.messageCount ?? 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <Button variant="link" asChild data-testid="thread-detail-back">
+          <NavLink to={`/organizations/${organizationId}/threads`}>← Back to Threads</NavLink>
+        </Button>
+      </div>
+      {threadQuery.isPending ? <div className="text-sm text-muted-foreground">Loading thread...</div> : null}
+      {threadQuery.isError ? <div className="text-sm text-muted-foreground">Failed to load thread.</div> : null}
+      {thread ? (
+        <Card className="border-border" data-testid="thread-detail-card">
+          <CardContent className="space-y-4">
+            <div>
+              <h3 className="text-lg font-semibold text-foreground">Thread details</h3>
+              <p className="text-sm text-muted-foreground">Status, counts, and timestamps.</p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Thread ID</div>
+                <div className="text-sm text-foreground">{thread.id}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Organization ID</div>
+                <div className="text-sm text-foreground">{thread.organizationId || EMPTY_PLACEHOLDER}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Status</div>
+                <Badge variant="secondary">{formatThreadStatus(thread.status)}</Badge>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Messages</div>
+                <div className="text-sm text-foreground">{messageCount.toLocaleString()}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Created</div>
+                <div className="text-sm text-foreground">{formatDateOnly(thread.createdAt)}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Updated</div>
+                <div className="text-sm text-foreground">{formatDateOnly(thread.updatedAt)}</div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+      <Card className="border-border" data-testid="thread-participants-card">
+        <CardHeader className="pb-0">
+          <CardTitle>Participants</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {participants.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No participants found.</div>
+          ) : (
+            <div className="divide-y divide-border">
+              {participants.map((participant) => (
+                <div
+                  key={participant.id}
+                  className="flex flex-wrap items-center justify-between gap-3 py-3"
+                  data-testid="thread-participant-row"
+                >
+                  <div>
+                    <div className="text-sm font-medium text-foreground">{formatHandle(participant.id)}</div>
+                    <div className="text-xs text-muted-foreground">{participant.id}</div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {participant.passive ? (
+                      <Badge variant="outline" className="text-xs text-muted-foreground">
+                        Passive
+                      </Badge>
+                    ) : null}
+                    <span className="text-xs text-muted-foreground">
+                      Joined {formatDateOnly(participant.joinedAt)}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      <Card className="border-border" data-testid="thread-messages-card">
+        <CardHeader className="pb-0">
+          <CardTitle>Messages</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {messagesQuery.isPending ? (
+            <div className="text-sm text-muted-foreground">Loading messages...</div>
+          ) : null}
+          {messagesQuery.isError ? (
+            <div className="text-sm text-muted-foreground">Failed to load messages.</div>
+          ) : null}
+          {messages.length === 0 && !messagesQuery.isPending ? (
+            <div className="text-sm text-muted-foreground">No messages yet.</div>
+          ) : null}
+          {messages.map((message) => (
+            <div
+              key={message.id}
+              className="rounded-lg border border-border p-4"
+              data-testid="thread-message-row"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="text-sm font-semibold text-foreground">{formatHandle(message.senderId)}</div>
+                <div className="text-xs text-muted-foreground">{formatTimestamp(message.createdAt)}</div>
+              </div>
+              <div className="mt-2 text-sm text-foreground whitespace-pre-wrap">
+                {message.body || EMPTY_PLACEHOLDER}
+              </div>
+              {message.fileIds.length > 0 ? (
+                <div className="mt-3 space-y-2">
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Attachments</div>
+                  <div className="space-y-1">
+                    {message.fileIds.map((fileId) => (
+                      <AttachmentLink key={fileId} fileId={fileId} />
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ))}
+          <LoadMoreButton
+            hasMore={messagesQuery.hasNextPage}
+            isLoading={messagesQuery.isFetchingNextPage}
+            onClick={() => messagesQuery.fetchNextPage()}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/OrganizationThreadDetailPage.tsx
+++ b/src/pages/OrganizationThreadDetailPage.tsx
@@ -2,15 +2,15 @@ import { useMemo } from 'react';
 import { NavLink, useParams } from 'react-router-dom';
 import { create } from '@bufbuild/protobuf';
 import { DurationSchema } from '@bufbuild/protobuf/wkt';
-import { Code, ConnectError } from '@connectrpc/connect';
-import { useInfiniteQuery, useQueries, useQuery } from '@tanstack/react-query';
-import { agentsClient, appsClient, filesClient, threadsClient, usersClient } from '@/api/client';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { filesClient, threadsClient } from '@/api/client';
 import { LoadMoreButton } from '@/components/LoadMoreButton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { MessageOrder } from '@/gen/agynio/api/threads/v1/threads_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { useIdentityHandles } from '@/hooks/useIdentityHandles';
 import {
   EMPTY_PLACEHOLDER,
   formatDateOnly,
@@ -67,10 +67,6 @@ function AttachmentLink({ fileId }: AttachmentLinkProps) {
   );
 }
 
-function isNotFound(error: unknown): boolean {
-  return error instanceof ConnectError && error.code === Code.NotFound;
-}
-
 export function OrganizationThreadDetailPage() {
   const { id, threadId } = useParams();
   const organizationId = id ?? '';
@@ -117,100 +113,7 @@ export function OrganizationThreadDetailPage() {
     });
     return Array.from(ids);
   }, [messages, participants]);
-
-  const usersQuery = useQuery({
-    queryKey: ['users', 'batch', identityIds.join(',')],
-    queryFn: () => usersClient.batchGetUsers({ identityIds }),
-    enabled: identityIds.length > 0,
-    staleTime: 60_000,
-    refetchOnWindowFocus: false,
-  });
-
-  const userMap = useMemo(() => {
-    const users = usersQuery.data?.users ?? [];
-    return new Map(
-      users.flatMap((user) => {
-        const userId = user.meta?.id;
-        return userId ? ([[userId, user]] as const) : [];
-      }),
-    );
-  }, [usersQuery.data?.users]);
-
-  const unresolvedIds = useMemo(
-    () => identityIds.filter((identityId) => !userMap.has(identityId)),
-    [identityIds, userMap],
-  );
-
-  const agentQueries = useQueries({
-    queries: unresolvedIds.map((identityId) => ({
-      queryKey: ['agents', 'identity', identityId],
-      queryFn: async () => {
-        try {
-          return await agentsClient.getAgent({ id: identityId });
-        } catch (error) {
-          if (isNotFound(error)) return null;
-          throw error;
-        }
-      },
-      enabled: Boolean(identityId),
-      retry: false,
-      staleTime: 60_000,
-      refetchOnWindowFocus: false,
-    })),
-  });
-
-  const agentMap = useMemo(
-    () =>
-      new Map(
-        agentQueries.flatMap((query, index) => {
-          const identityId = unresolvedIds[index];
-          const agent = query.data?.agent;
-          return identityId && agent ? ([[identityId, agent]] as const) : [];
-        }),
-      ),
-    [agentQueries, unresolvedIds],
-  );
-
-  const appProfileQueries = useQueries({
-    queries: unresolvedIds.map((identityId) => ({
-      queryKey: ['apps', 'profile', identityId],
-      queryFn: async () => {
-        try {
-          return await appsClient.getAppProfile({ identityId });
-        } catch (error) {
-          if (isNotFound(error)) return null;
-          throw error;
-        }
-      },
-      enabled: Boolean(identityId),
-      retry: false,
-      staleTime: 60_000,
-      refetchOnWindowFocus: false,
-    })),
-  });
-
-  const appProfileMap = useMemo(
-    () =>
-      new Map(
-        appProfileQueries.flatMap((query, index) => {
-          const identityId = unresolvedIds[index];
-          const profile = query.data?.profile;
-          return identityId && profile ? ([[identityId, profile]] as const) : [];
-        }),
-      ),
-    [appProfileQueries, unresolvedIds],
-  );
-
-  const formatHandle = (identityId?: string | null) => {
-    if (!identityId) return EMPTY_PLACEHOLDER;
-    const user = userMap.get(identityId);
-    if (user) return `@${user.nickname || user.name || user.email || identityId}`;
-    const agent = agentMap.get(identityId);
-    if (agent) return `@${agent.nickname || agent.name || identityId}`;
-    const appProfile = appProfileMap.get(identityId);
-    if (appProfile) return `@${appProfile.name || appProfile.slug || identityId}`;
-    return `@${identityId}`;
-  };
+  const { formatHandle } = useIdentityHandles(identityIds);
 
   const threadTitle = thread?.id ? `Thread ${truncate(thread.id, 12)}` : 'Thread';
   useDocumentTitle(threadTitle);

--- a/src/pages/OrganizationThreadsTab.tsx
+++ b/src/pages/OrganizationThreadsTab.tsx
@@ -5,6 +5,7 @@ import { threadsClient } from '@/api/client';
 import { LoadMoreButton } from '@/components/LoadMoreButton';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
+import { ThreadStatus } from '@/gen/agynio/api/threads/v1/threads_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useIdentityHandles } from '@/hooks/useIdentityHandles';
 import { EMPTY_PLACEHOLDER, formatDateOnly, formatThreadStatus, truncate } from '@/lib/format';
@@ -19,10 +20,11 @@ export function OrganizationThreadsTab() {
   const threadsQuery = useInfiniteQuery({
     queryKey: ['threads', organizationId, 'list'],
     queryFn: ({ pageParam }) =>
-      threadsClient.listOrganizationThreads({
+      threadsClient.getOrganizationThreads({
         organizationId,
         pageSize: DEFAULT_PAGE_SIZE,
         pageToken: pageParam,
+        status: ThreadStatus.UNSPECIFIED,
       }),
     initialPageParam: '',
     getNextPageParam: (lastPage) => lastPage.nextPageToken || undefined,

--- a/src/pages/OrganizationThreadsTab.tsx
+++ b/src/pages/OrganizationThreadsTab.tsx
@@ -1,0 +1,97 @@
+import { NavLink, useParams } from 'react-router-dom';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { threadsClient } from '@/api/client';
+import { LoadMoreButton } from '@/components/LoadMoreButton';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { formatDateOnly, formatThreadStatus, truncate } from '@/lib/format';
+import { DEFAULT_PAGE_SIZE } from '@/lib/pagination';
+
+export function OrganizationThreadsTab() {
+  useDocumentTitle('Threads');
+
+  const { id } = useParams();
+  const organizationId = id ?? '';
+
+  const threadsQuery = useInfiniteQuery({
+    queryKey: ['threads', organizationId, 'list'],
+    queryFn: ({ pageParam }) =>
+      threadsClient.listOrganizationThreads({
+        organizationId,
+        pageSize: DEFAULT_PAGE_SIZE,
+        pageToken: pageParam,
+      }),
+    initialPageParam: '',
+    getNextPageParam: (lastPage) => lastPage.nextPageToken || undefined,
+    enabled: Boolean(organizationId),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const threads = threadsQuery.data?.pages.flatMap((page) => page.threads) ?? [];
+  const isLoading = threadsQuery.isPending;
+  const isError = threadsQuery.isError;
+
+  return (
+    <div className="space-y-4">
+      {isLoading ? <div className="text-sm text-muted-foreground">Loading threads...</div> : null}
+      {isError ? <div className="text-sm text-muted-foreground">Failed to load threads.</div> : null}
+      {threads.length === 0 && !isLoading ? (
+        <Card className="border-border" data-testid="organization-threads-empty">
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            No threads yet.
+          </CardContent>
+        </Card>
+      ) : null}
+      {threads.length > 0 ? (
+        <Card className="border-border" data-testid="organization-threads-table">
+          <CardContent className="px-0">
+            <div className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_1fr_1fr_1fr]">
+              <span>Thread</span>
+              <span>Status</span>
+              <span>Messages</span>
+              <span>Created</span>
+            </div>
+            <div className="divide-y divide-border">
+              {threads.map((thread) => {
+                const threadId = thread.id;
+                const messageCount = thread.messageCount ?? 0;
+
+                return (
+                  <NavLink
+                    key={threadId}
+                    to={`/organizations/${organizationId}/threads/${threadId}`}
+                    className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_1fr_1fr] hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    data-testid="organization-thread-row"
+                  >
+                    <div>
+                      <div className="font-medium" data-testid="organization-thread-id">
+                        {truncate(threadId, 18)}
+                      </div>
+                      <div className="text-xs text-muted-foreground">{threadId}</div>
+                    </div>
+                    <Badge variant="secondary" data-testid="organization-thread-status">
+                      {formatThreadStatus(thread.status)}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground" data-testid="organization-thread-messages">
+                      {messageCount.toLocaleString()}
+                    </span>
+                    <span className="text-xs text-muted-foreground" data-testid="organization-thread-created">
+                      {formatDateOnly(thread.createdAt)}
+                    </span>
+                  </NavLink>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+      <LoadMoreButton
+        hasMore={threadsQuery.hasNextPage}
+        isLoading={threadsQuery.isFetchingNextPage}
+        onClick={() => threadsQuery.fetchNextPage()}
+      />
+    </div>
+  );
+}

--- a/src/pages/OrganizationThreadsTab.tsx
+++ b/src/pages/OrganizationThreadsTab.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { NavLink, useParams } from 'react-router-dom';
+import { Code, ConnectError } from '@connectrpc/connect';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { threadsClient } from '@/api/client';
 import { LoadMoreButton } from '@/components/LoadMoreButton';
@@ -39,6 +40,8 @@ export function OrganizationThreadsTab() {
   );
   const isLoading = threadsQuery.isPending;
   const isError = threadsQuery.isError;
+  const isPermissionDenied =
+    threadsQuery.error instanceof ConnectError && threadsQuery.error.code === Code.PermissionDenied;
 
   const identityIds = useMemo(() => {
     const ids = new Set<string>();
@@ -55,8 +58,12 @@ export function OrganizationThreadsTab() {
   return (
     <div className="space-y-4">
       {isLoading ? <div className="text-sm text-muted-foreground">Loading threads...</div> : null}
-      {isError ? <div className="text-sm text-muted-foreground">Failed to load threads.</div> : null}
-      {threads.length === 0 && !isLoading ? (
+      {isError ? (
+        <div className="text-sm text-muted-foreground">
+          {isPermissionDenied ? 'You do not have permission to view threads.' : 'Failed to load threads.'}
+        </div>
+      ) : null}
+      {threads.length === 0 && !isLoading && !isError ? (
         <Card className="border-border" data-testid="organization-threads-empty">
           <CardContent className="py-10 text-center text-sm text-muted-foreground">
             No threads yet.

--- a/src/pages/OrganizationThreadsTab.tsx
+++ b/src/pages/OrganizationThreadsTab.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { NavLink, useParams } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { threadsClient } from '@/api/client';
@@ -5,7 +6,8 @@ import { LoadMoreButton } from '@/components/LoadMoreButton';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { formatDateOnly, formatThreadStatus, truncate } from '@/lib/format';
+import { useIdentityHandles } from '@/hooks/useIdentityHandles';
+import { EMPTY_PLACEHOLDER, formatDateOnly, formatThreadStatus, truncate } from '@/lib/format';
 import { DEFAULT_PAGE_SIZE } from '@/lib/pagination';
 
 export function OrganizationThreadsTab() {
@@ -29,9 +31,24 @@ export function OrganizationThreadsTab() {
     refetchOnWindowFocus: false,
   });
 
-  const threads = threadsQuery.data?.pages.flatMap((page) => page.threads) ?? [];
+  const threads = useMemo(
+    () => threadsQuery.data?.pages.flatMap((page) => page.threads) ?? [],
+    [threadsQuery.data?.pages],
+  );
   const isLoading = threadsQuery.isPending;
   const isError = threadsQuery.isError;
+
+  const identityIds = useMemo(() => {
+    const ids = new Set<string>();
+    threads.forEach((thread) => {
+      thread.participants.forEach((participant) => {
+        if (participant.id) ids.add(participant.id);
+      });
+    });
+    return Array.from(ids);
+  }, [threads]);
+
+  const { formatHandle } = useIdentityHandles(identityIds);
 
   return (
     <div className="space-y-4">
@@ -47,8 +64,9 @@ export function OrganizationThreadsTab() {
       {threads.length > 0 ? (
         <Card className="border-border" data-testid="organization-threads-table">
           <CardContent className="px-0">
-            <div className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_1fr_1fr_1fr]">
+            <div className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_2fr_1fr_1fr_1fr]">
               <span>Thread</span>
+              <span>Participants</span>
               <span>Status</span>
               <span>Messages</span>
               <span>Created</span>
@@ -57,12 +75,19 @@ export function OrganizationThreadsTab() {
               {threads.map((thread) => {
                 const threadId = thread.id;
                 const messageCount = thread.messageCount ?? 0;
+                const participantHandles = thread.participants
+                  .map((participant) => formatHandle(participant.id))
+                  .filter((handle) => handle !== EMPTY_PLACEHOLDER);
+                const participantsLabel =
+                  participantHandles.length > 0
+                    ? truncate(participantHandles.join(', '), 60)
+                    : EMPTY_PLACEHOLDER;
 
                 return (
                   <NavLink
                     key={threadId}
                     to={`/organizations/${organizationId}/threads/${threadId}`}
-                    className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_1fr_1fr] hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_2fr_1fr_1fr_1fr] hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     data-testid="organization-thread-row"
                   >
                     <div>
@@ -70,6 +95,12 @@ export function OrganizationThreadsTab() {
                         {truncate(threadId, 18)}
                       </div>
                       <div className="text-xs text-muted-foreground">{threadId}</div>
+                    </div>
+                    <div
+                      className="text-xs text-muted-foreground"
+                      data-testid="organization-thread-participants"
+                    >
+                      {participantsLabel}
                     </div>
                     <Badge variant="secondary" data-testid="organization-thread-status">
                       {formatThreadStatus(thread.status)}

--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -14,6 +14,7 @@ const SECRETS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.SecretsGateway';
 const AGENTS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.AgentsGateway';
 const LLM_GATEWAY_PATH = '/api/agynio.api.gateway.v1.LLMGateway';
 const RUNNERS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.RunnersGateway';
+const THREADS_GATEWAY_PATH = '/api/agynio.api.gateway.v1.ThreadsGateway';
 const METERING_GATEWAY_PATH = '/api/agynio.api.gateway.v1.MeteringGateway';
 
 const CONNECT_HEADERS = {
@@ -58,8 +59,41 @@ type DeviceWire = {
   enrollmentJwt?: string;
 };
 
+type ThreadParticipantWire = {
+  id?: string;
+  joinedAt?: string;
+  passive?: boolean;
+};
+
+type ThreadWire = {
+  id?: string;
+  participants?: ThreadParticipantWire[];
+  status?: string | number;
+  createdAt?: string;
+  updatedAt?: string;
+  organizationId?: string;
+  messageCount?: number;
+};
+
+type MessageWire = {
+  id?: string;
+  threadId?: string;
+  senderId?: string;
+  body?: string;
+  fileIds?: string[];
+  createdAt?: string;
+};
+
 type CreateOrganizationResponseWire = {
   organization?: { id?: string };
+};
+
+type CreateThreadResponseWire = {
+  thread?: ThreadWire;
+};
+
+type SendMessageResponseWire = {
+  message?: MessageWire;
 };
 
 type ListAccessibleOrganizationsResponseWire = {
@@ -422,6 +456,48 @@ export async function setSelectedOrganization(page: Page, organizationId: string
     );
     window.localStorage.removeItem('console.selectedOrganization');
   }, organizationId);
+}
+
+export async function createThread(
+  page: Page,
+  opts: { organizationId: string; participantIds: string[] },
+): Promise<string> {
+  const response = await postConnect<CreateThreadResponseWire>(
+    page,
+    THREADS_GATEWAY_PATH,
+    'CreateThread',
+    {
+      organizationId: opts.organizationId,
+      participantIds: opts.participantIds,
+    },
+  );
+  const threadId = response.thread?.id;
+  if (!threadId) {
+    throw new Error('CreateThread response missing thread id.');
+  }
+  return threadId;
+}
+
+export async function sendThreadMessage(
+  page: Page,
+  opts: { threadId: string; senderId: string; body: string; fileIds?: string[] },
+): Promise<string> {
+  const response = await postConnect<SendMessageResponseWire>(
+    page,
+    THREADS_GATEWAY_PATH,
+    'SendMessage',
+    {
+      threadId: opts.threadId,
+      senderId: opts.senderId,
+      body: opts.body,
+      fileIds: opts.fileIds ?? [],
+    },
+  );
+  const messageId = response.message?.id;
+  if (!messageId) {
+    throw new Error('SendMessage response missing message id.');
+  }
+  return messageId;
 }
 
 export async function createUser(

--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -462,13 +462,16 @@ export async function createThread(
   page: Page,
   opts: { organizationId: string; participantIds: string[] },
 ): Promise<string> {
+  const me = await getMe(page);
+  const initiatorId = me.user?.meta?.id ?? '';
+  const participantIds = opts.participantIds.filter((participantId) => participantId !== initiatorId);
   const response = await postConnect<CreateThreadResponseWire>(
     page,
     THREADS_GATEWAY_PATH,
     'CreateThread',
     {
       organizationId: opts.organizationId,
-      participantIds: opts.participantIds,
+      participantIds,
     },
   );
   const threadId = response.thread?.id;

--- a/test/e2e/mock-server.mjs
+++ b/test/e2e/mock-server.mjs
@@ -24,6 +24,11 @@ const llmProviders = new Map();
 const models = new Map();
 const imagePullSecretAttachments = new Map();
 const usageTotals = new Map();
+const threads = new Map();
+const threadMessages = new Map();
+
+let threadSequence = 0;
+let messageSequence = 0;
 
 const defaultUser = {
   id: defaultUserId,
@@ -167,6 +172,20 @@ function normalizeClusterRole(value) {
   return 'CLUSTER_ROLE_UNSPECIFIED';
 }
 
+function normalizeThreadStatus(value) {
+  if (typeof value === 'string') return value;
+  if (value === 1) return 'THREAD_STATUS_ACTIVE';
+  if (value === 2) return 'THREAD_STATUS_ARCHIVED';
+  return 'THREAD_STATUS_UNSPECIFIED';
+}
+
+function normalizeMessageOrder(value) {
+  if (typeof value === 'string') return value;
+  if (value === 1) return 'MESSAGE_ORDER_OLDEST_FIRST';
+  if (value === 2) return 'MESSAGE_ORDER_NEWEST_FIRST';
+  return 'MESSAGE_ORDER_UNSPECIFIED';
+}
+
 function normalizeGranularity(value) {
   if (typeof value === 'string') return value;
   if (value === 1) return 'GRANULARITY_TOTAL';
@@ -188,6 +207,22 @@ function normalizeInt64(value) {
   if (typeof value === 'number') return BigInt(value);
   if (typeof value === 'string') return BigInt(value);
   return 0n;
+}
+
+function parsePageToken(token) {
+  if (!token) return 0;
+  const parsed = Number.parseInt(token, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function paginate(items, pageSize, pageToken) {
+  const size = Number(pageSize) > 0 ? Number(pageSize) : items.length;
+  const start = parsePageToken(pageToken);
+  const end = start + size;
+  return {
+    items: items.slice(start, end),
+    nextPageToken: end < items.length ? String(end) : '',
+  };
 }
 
 function recordUsageTotal(orgId, value) {
@@ -389,6 +424,37 @@ function mapImagePullSecretAttachment(attachment) {
     meta: mapEntityMeta(attachment),
     imagePullSecretId: attachment.imagePullSecretId,
     target: attachment.target,
+  };
+}
+
+function mapThreadParticipant(participant) {
+  return {
+    id: participant.id,
+    joinedAt: participant.joinedAt,
+    passive: Boolean(participant.passive),
+  };
+}
+
+function mapThread(thread) {
+  return {
+    id: thread.id,
+    participants: thread.participants.map(mapThreadParticipant),
+    status: thread.status,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+    organizationId: thread.organizationId,
+    messageCount: thread.messageCount,
+  };
+}
+
+function mapThreadMessage(message) {
+  return {
+    id: message.id,
+    threadId: message.threadId,
+    senderId: message.senderId,
+    body: message.body,
+    fileIds: message.fileIds ?? [],
+    createdAt: message.createdAt,
   };
 }
 
@@ -864,6 +930,135 @@ function handleAgentsGateway(method, body, res) {
   }
 }
 
+function handleThreadsGateway(method, body, res) {
+  switch (method) {
+    case 'CreateThread': {
+      const id = randomUUID();
+      const createdAt = new Date(Date.now() + threadSequence).toISOString();
+      threadSequence += 1000;
+      const participantIds = Array.isArray(body.participantIds) ? body.participantIds : [];
+      const participantIdentifiers = Array.isArray(body.participants) ? body.participants : [];
+      const resolvedIds = participantIdentifiers
+        .map((participant) => participant.participantId || participant.participantNickname)
+        .filter(Boolean);
+      const uniqueIds = Array.from(new Set([...participantIds, ...resolvedIds].filter(Boolean)));
+      const participants = uniqueIds.map((participantId) => ({
+        id: participantId,
+        joinedAt: createdAt,
+        passive: false,
+      }));
+      const thread = {
+        id,
+        participants,
+        status: 'THREAD_STATUS_ACTIVE',
+        createdAt,
+        updatedAt: createdAt,
+        organizationId: body.organizationId ?? '',
+        messageCount: 0,
+      };
+      threads.set(id, thread);
+      threadMessages.set(id, []);
+      return sendJson(res, 200, { thread: mapThread(thread) });
+    }
+    case 'ArchiveThread': {
+      const thread = threads.get(body.threadId);
+      if (!thread) return sendText(res, 404, 'Thread not found');
+      thread.status = 'THREAD_STATUS_ARCHIVED';
+      thread.updatedAt = new Date(Date.now() + threadSequence).toISOString();
+      threadSequence += 1000;
+      return sendJson(res, 200, { thread: mapThread(thread) });
+    }
+    case 'AddParticipant': {
+      const thread = threads.get(body.threadId);
+      if (!thread) return sendText(res, 404, 'Thread not found');
+      const participantId =
+        body.participantId ?? body.participant?.participantId ?? body.participant?.participantNickname ?? '';
+      if (!participantId) return sendText(res, 400, 'Missing participant id');
+      if (!thread.participants.some((participant) => participant.id === participantId)) {
+        thread.participants.push({
+          id: participantId,
+          joinedAt: new Date(Date.now() + threadSequence).toISOString(),
+          passive: Boolean(body.passive),
+        });
+        threadSequence += 1000;
+      }
+      return sendJson(res, 200, { thread: mapThread(thread) });
+    }
+    case 'SendMessage': {
+      const threadId = body.threadId ?? '';
+      const thread = threads.get(threadId);
+      if (!thread) return sendText(res, 404, 'Thread not found');
+      const createdAt = new Date(Date.now() + messageSequence).toISOString();
+      messageSequence += 1;
+      const message = {
+        id: randomUUID(),
+        threadId,
+        senderId: body.senderId ?? '',
+        body: body.body ?? '',
+        fileIds: Array.isArray(body.fileIds) ? body.fileIds : [],
+        createdAt,
+      };
+      const messages = threadMessages.get(threadId) ?? [];
+      messages.push(message);
+      threadMessages.set(threadId, messages);
+      thread.messageCount = messages.length;
+      thread.updatedAt = createdAt;
+      if (message.senderId && !thread.participants.some((participant) => participant.id === message.senderId)) {
+        thread.participants.push({
+          id: message.senderId,
+          joinedAt: createdAt,
+          passive: false,
+        });
+      }
+      return sendJson(res, 200, { message: mapThreadMessage(message) });
+    }
+    case 'GetThreads': {
+      const participantId = body.participantId ?? '';
+      let result = Array.from(threads.values());
+      if (participantId) {
+        result = result.filter((thread) =>
+          thread.participants.some((participant) => participant.id === participantId),
+        );
+      }
+      result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      const { items, nextPageToken } = paginate(result, body.pageSize, body.pageToken);
+      return sendJson(res, 200, { threads: items.map(mapThread), nextPageToken });
+    }
+    case 'GetOrganizationThreads': {
+      const orgId = body.organizationId ?? '';
+      const statusFilter = normalizeThreadStatus(body.status);
+      let result = Array.from(threads.values()).filter((thread) => thread.organizationId === orgId);
+      if (statusFilter !== 'THREAD_STATUS_UNSPECIFIED') {
+        result = result.filter((thread) => thread.status === statusFilter);
+      }
+      result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      const { items, nextPageToken } = paginate(result, body.pageSize, body.pageToken);
+      return sendJson(res, 200, { threads: items.map(mapThread), nextPageToken });
+    }
+    case 'GetThread': {
+      const thread = threads.get(body.threadId);
+      if (!thread) return sendText(res, 404, 'Thread not found');
+      return sendJson(res, 200, { thread: mapThread(thread) });
+    }
+    case 'GetMessages': {
+      const threadId = body.threadId ?? '';
+      const messages = threadMessages.get(threadId);
+      if (!messages) return sendText(res, 404, 'Thread not found');
+      const order = normalizeMessageOrder(body.order);
+      const ordered = [...messages].sort((a, b) => {
+        const aTime = new Date(a.createdAt).getTime();
+        const bTime = new Date(b.createdAt).getTime();
+        if (order === 'MESSAGE_ORDER_NEWEST_FIRST') return bTime - aTime;
+        return aTime - bTime;
+      });
+      const { items, nextPageToken } = paginate(ordered, body.pageSize, body.pageToken);
+      return sendJson(res, 200, { messages: items.map(mapThreadMessage), nextPageToken });
+    }
+    default:
+      return sendText(res, 404, 'Unknown ThreadsGateway method');
+  }
+}
+
 function handleAppsGateway(method, _body, res) {
   if (method === 'ListInstallations') {
     return sendJson(res, 200, { installations: [], nextPageToken: '' });
@@ -1062,6 +1257,9 @@ const server = http.createServer(async (req, res) => {
     }
     if (service === 'agynio.api.gateway.v1.AgentsGateway') {
       return handleAgentsGateway(method, body, res);
+    }
+    if (service === 'agynio.api.gateway.v1.ThreadsGateway') {
+      return handleThreadsGateway(method, body, res);
     }
     if (service === 'agynio.api.gateway.v1.MeteringGateway') {
       return handleMeteringGateway(method, body, res);

--- a/test/e2e/organization-threads.spec.ts
+++ b/test/e2e/organization-threads.spec.ts
@@ -1,0 +1,46 @@
+import { argosScreenshot } from '@argos-ci/playwright';
+import { test, expect } from './fixtures';
+import { createOrganization, createThread, getMe, sendThreadMessage, setSelectedOrganization } from './console-api';
+
+test('org threads list and detail pagination', async ({ page }) => {
+  const organizationId = await createOrganization(page, `e2e-org-threads-${Date.now()}`);
+  await setSelectedOrganization(page, organizationId);
+  const me = await getMe(page);
+  const identityId = me.user?.meta?.id;
+  if (!identityId) {
+    throw new Error('GetMe response missing identity id for threads test.');
+  }
+
+  const threadOne = await createThread(page, { organizationId, participantIds: [identityId] });
+  await sendThreadMessage(page, { threadId: threadOne, senderId: identityId, body: 'First thread message.' });
+
+  const threadTwo = await createThread(page, { organizationId, participantIds: [identityId] });
+  const totalMessages = 55;
+  for (let index = 0; index < totalMessages; index += 1) {
+    await sendThreadMessage(page, {
+      threadId: threadTwo,
+      senderId: identityId,
+      body: `Thread message ${index + 1}`,
+    });
+  }
+
+  await page.goto(`/organizations/${organizationId}/threads`);
+  await expect(page.getByTestId('organization-threads-table')).toBeVisible({ timeout: 15000 });
+  const rows = page.getByTestId('organization-thread-row');
+  await expect(rows.first()).toContainText(threadTwo);
+  await expect(rows.filter({ hasText: threadOne })).toBeVisible();
+  await expect(rows.first().getByTestId('organization-thread-messages')).toHaveText('55');
+  await argosScreenshot(page, 'organization-threads-list');
+
+  await rows.first().click();
+  await expect(page.getByTestId('thread-detail-card')).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId('thread-participants-card')).toBeVisible();
+  await expect(page.getByTestId('thread-messages-card')).toBeVisible();
+
+  await expect(page.getByTestId('thread-message-row')).toHaveCount(50);
+  const loadMoreButton = page.getByTestId('thread-messages-card').getByTestId('load-more');
+  await expect(loadMoreButton).toBeVisible();
+  await loadMoreButton.click();
+  await expect(page.getByTestId('thread-message-row')).toHaveCount(totalMessages);
+  await expect(page.getByTestId('thread-messages-card').getByTestId('load-more')).toHaveCount(0);
+});

--- a/test/e2e/organization-threads.spec.ts
+++ b/test/e2e/organization-threads.spec.ts
@@ -1,6 +1,13 @@
 import { argosScreenshot } from '@argos-ci/playwright';
 import { test, expect } from './fixtures';
-import { createOrganization, createThread, getMe, sendThreadMessage, setSelectedOrganization } from './console-api';
+import {
+  createOrganization,
+  createThread,
+  createUser,
+  getMe,
+  sendThreadMessage,
+  setSelectedOrganization,
+} from './console-api';
 
 test('org threads list and detail pagination', async ({ page }) => {
   const organizationId = await createOrganization(page, `e2e-org-threads-${Date.now()}`);
@@ -11,10 +18,15 @@ test('org threads list and detail pagination', async ({ page }) => {
     throw new Error('GetMe response missing identity id for threads test.');
   }
 
-  const threadOne = await createThread(page, { organizationId, participantIds: [identityId] });
+  const participantId = await createUser(page, {
+    email: `e2e-thread-participant-${Date.now()}@agyn.test`,
+    nickname: 'thread-participant',
+  });
+
+  const threadOne = await createThread(page, { organizationId, participantIds: [participantId] });
   await sendThreadMessage(page, { threadId: threadOne, senderId: identityId, body: 'First thread message.' });
 
-  const threadTwo = await createThread(page, { organizationId, participantIds: [identityId] });
+  const threadTwo = await createThread(page, { organizationId, participantIds: [participantId] });
   const totalMessages = 55;
   for (let index = 0; index < totalMessages; index += 1) {
     await sendThreadMessage(page, {

--- a/test/e2e/organization-threads.spec.ts
+++ b/test/e2e/organization-threads.spec.ts
@@ -50,8 +50,11 @@ test('org threads list and detail pagination', async ({ page }) => {
   await expect(page.getByTestId('thread-messages-card')).toBeVisible();
 
   await expect(page.getByTestId('thread-message-row')).toHaveCount(50);
+  await expect(page.getByTestId('thread-message-row').first()).toContainText('Thread message 55');
   const loadMoreButton = page.getByTestId('thread-messages-card').getByTestId('load-more');
   await expect(loadMoreButton).toBeVisible();
+  await expect(loadMoreButton).toHaveText('Load more');
+  await argosScreenshot(page, 'organization-thread-detail');
   await loadMoreButton.click();
   await expect(page.getByTestId('thread-message-row')).toHaveCount(totalMessages);
   await expect(page.getByTestId('thread-messages-card').getByTestId('load-more')).toHaveCount(0);


### PR DESCRIPTION
## Summary
- add organization threads list with message count/status/created date and pagination
- add thread detail view with participants, newest-first messages, and attachment download links
- wire threads navigation, routes, and API clients

## Testing
- npx buf generate ../api
- npm run lint
- npm run typecheck
- npm run test

#67