### PR TITLE
feat(console-app): show degraded thread status

### DIFF
--- a/src/__tests__/format-thread-status.test.ts
+++ b/src/__tests__/format-thread-status.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ThreadStatus } from '@/gen/agynio/api/threads/v1/threads_pb';
+import { formatThreadStatus } from '@/lib/format';
+
+describe('formatThreadStatus', () => {
+  it('formats active status', () => {
+    expect(formatThreadStatus(ThreadStatus.ACTIVE)).toBe('Active');
+  });
+
+  it('formats archived status', () => {
+    expect(formatThreadStatus(ThreadStatus.ARCHIVED)).toBe('Archived');
+  });
+
+  it('formats degraded status', () => {
+    expect(formatThreadStatus(ThreadStatus.DEGRADED)).toBe('Degraded');
+  });
+
+  it('formats unspecified status', () => {
+    expect(formatThreadStatus(ThreadStatus.UNSPECIFIED)).toBe('Unspecified');
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -145,6 +145,7 @@ export function formatMembershipStatus(status?: MembershipStatus): string {
 export function formatThreadStatus(status?: ThreadStatus): string {
   if (status === ThreadStatus.ACTIVE) return 'Active';
   if (status === ThreadStatus.ARCHIVED) return 'Archived';
+  if (status === ThreadStatus.DEGRADED) return 'Degraded';
   if (status === ThreadStatus.UNSPECIFIED) return 'Unspecified';
   return 'Unspecified';
 }


### PR DESCRIPTION
## Summary
- add degraded status formatting for threads
- cover thread status formatting in tests

## Testing
- npm run generate
- npm run lint
- npm run typecheck
- npm test
- npm run build

## Tracking
Part of https://github.com/agynio/agents-orchestrator/issues/148