### PR TITLE
feat(secrets): add local storage mode

### DIFF
--- a/src/pages/OrganizationSecretsTab.tsx
+++ b/src/pages/OrganizationSecretsTab.tsx
@@ -29,15 +29,12 @@ import { toast } from 'sonner';
 type StorageMode = 'local' | 'remote';
 type SecretStorageState = StorageMode | 'invalid';
 
-const STORAGE_MODE_OPTIONS: Array<{ value: StorageMode; label: string }> = [
-  { value: 'local', label: 'Local (built-in)' },
-  { value: 'remote', label: 'Remote provider' },
-];
+const BUILT_IN_PROVIDER_ID = '__built-in__';
+const BUILT_IN_PROVIDER_LABEL = 'Built-in';
 
 type SecretFormValues = {
   title: string;
   description: string;
-  storageMode: StorageMode;
   value: string;
   providerId: string;
   remoteName: string;
@@ -68,9 +65,8 @@ type CreateSecretPayload =
 const DEFAULT_FORM_VALUES: SecretFormValues = {
   title: '',
   description: '',
-  storageMode: 'remote',
   value: '',
-  providerId: '',
+  providerId: BUILT_IN_PROVIDER_ID,
   remoteName: '',
 };
 
@@ -93,6 +89,8 @@ const resolveSecretStorageState = (secret: Secret): SecretStorageState => {
   return 'invalid';
 };
 
+const isBuiltInProviderSelection = (providerId: string) => providerId === BUILT_IN_PROVIDER_ID;
+
 const resolveSecretInvalidReason = (secret: Secret): string => {
   const hasProvider = Boolean(secret.secretProviderId.trim());
   const hasRemote = Boolean(secret.remoteName.trim());
@@ -102,23 +100,18 @@ const resolveSecretInvalidReason = (secret: Secret): string => {
   return 'Invalid configuration.';
 };
 
-const resolveFormStorageMode = (secret: Secret): StorageMode => {
-  const state = resolveSecretStorageState(secret);
-  return state === 'remote' || state === 'invalid' ? 'remote' : 'local';
-};
-
 const buildFormValuesFromSecret = (secret: Secret | null): SecretFormValues => {
   if (!secret) return { ...DEFAULT_FORM_VALUES };
 
-  const storageMode = resolveFormStorageMode(secret);
+  const storageMode = resolveSecretStorageState(secret);
+  const isBuiltIn = storageMode === 'local';
 
   return {
     title: secret.title,
     description: secret.description,
-    storageMode,
     value: '',
-    providerId: storageMode === 'remote' ? secret.secretProviderId : '',
-    remoteName: storageMode === 'remote' ? secret.remoteName : '',
+    providerId: isBuiltIn ? BUILT_IN_PROVIDER_ID : secret.secretProviderId,
+    remoteName: isBuiltIn ? '' : secret.remoteName,
   };
 };
 
@@ -129,7 +122,7 @@ function validateSecretForm(values: SecretFormValues, mode: 'create' | 'edit'): 
     errors.title = 'Title is required.';
   }
 
-  if (values.storageMode === 'local') {
+  if (isBuiltInProviderSelection(values.providerId)) {
     if (mode === 'create' && !values.value.trim()) {
       errors.value = 'Secret value is required.';
     }
@@ -196,18 +189,19 @@ function SecretFormDialog({
   const pendingLabel = mode === 'create' ? 'Adding...' : 'Saving...';
   const valueLabel = mode === 'create' ? 'Secret Value' : 'New Secret Value';
   const valuePlaceholder = mode === 'create' ? 'Secret value' : 'Enter a new value';
+  const isBuiltInSelection = isBuiltInProviderSelection(values.providerId);
 
   const clearError = (field: keyof SecretFormErrors) => {
     setErrors((prev) => (prev[field] ? { ...prev, [field]: undefined } : prev));
   };
 
-  const handleStorageModeChange = (nextMode: StorageMode) => {
+  const handleProviderChange = (nextProviderId: string) => {
+    const isBuiltIn = isBuiltInProviderSelection(nextProviderId);
     setValues((prev) => ({
       ...prev,
-      storageMode: nextMode,
-      value: nextMode === 'local' ? prev.value : '',
-      providerId: nextMode === 'remote' ? prev.providerId : '',
-      remoteName: nextMode === 'remote' ? prev.remoteName : '',
+      providerId: nextProviderId,
+      value: isBuiltIn ? prev.value : '',
+      remoteName: isBuiltIn ? '' : prev.remoteName,
     }));
     setErrors((prev) => ({
       ...prev,
@@ -256,29 +250,44 @@ function SecretFormDialog({
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor={`${testIdPrefix}-storage-mode`}>Storage Mode</Label>
-            <Select
-              value={values.storageMode}
-              onValueChange={(value) => handleStorageModeChange(value as StorageMode)}
-              disabled={storageModeLocked}
-            >
-              <SelectTrigger id={`${testIdPrefix}-storage-mode`} data-testid={`${testIdPrefix}-storage-mode`}>
-                <SelectValue placeholder="Select mode" />
+            <Label htmlFor={`${testIdPrefix}-provider`}>Secret provider</Label>
+            <Select value={values.providerId} onValueChange={handleProviderChange}>
+              <SelectTrigger id={`${testIdPrefix}-provider`} data-testid={`${testIdPrefix}-provider`}>
+                <SelectValue placeholder="Select provider" />
               </SelectTrigger>
               <SelectContent>
-                {STORAGE_MODE_OPTIONS.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
+                <SelectItem
+                  value={BUILT_IN_PROVIDER_ID}
+                  disabled={storageModeLocked && !isBuiltInSelection}
+                >
+                  {BUILT_IN_PROVIDER_LABEL}
+                </SelectItem>
+                {providers.map((provider) => {
+                  const providerId = provider.meta?.id;
+                  if (!providerId) return null;
+                  return (
+                    <SelectItem
+                      key={providerId}
+                      value={providerId}
+                      disabled={storageModeLocked && isBuiltInSelection}
+                    >
+                      {provider.title}
+                    </SelectItem>
+                  );
+                })}
               </SelectContent>
             </Select>
-          {storageModeLocked ? (
-            <p className="text-xs text-muted-foreground">Storage mode cannot be changed after creation.</p>
-          ) : null}
-          {storageModeNotice ? <p className="text-xs text-destructive">{storageModeNotice}</p> : null}
-        </div>
-          {values.storageMode === 'local' ? (
+            {errors.providerId ? (
+              <p className="text-sm text-destructive" data-testid={`${testIdPrefix}-provider-error`}>
+                {errors.providerId}
+              </p>
+            ) : null}
+            {storageModeLocked ? (
+              <p className="text-xs text-muted-foreground">Storage mode cannot be changed after creation.</p>
+            ) : null}
+            {storageModeNotice ? <p className="text-xs text-destructive">{storageModeNotice}</p> : null}
+          </div>
+          {isBuiltInSelection ? (
             <div className="space-y-2">
               <Label htmlFor={`${testIdPrefix}-value`}>{valueLabel}</Label>
               <Input
@@ -302,56 +311,24 @@ function SecretFormDialog({
               ) : null}
             </div>
           ) : (
-            <div className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor={`${testIdPrefix}-provider`}>Secret Provider</Label>
-                <Select
-                  value={values.providerId}
-                  onValueChange={(value) => {
-                    setValues((prev) => ({ ...prev, providerId: value }));
-                    clearError('providerId');
-                  }}
-                >
-                  <SelectTrigger id={`${testIdPrefix}-provider`} data-testid={`${testIdPrefix}-provider`}>
-                    <SelectValue placeholder="Select provider" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {providers.map((provider) => {
-                      const providerId = provider.meta?.id;
-                      if (!providerId) return null;
-                      return (
-                        <SelectItem key={providerId} value={providerId}>
-                          {provider.title}
-                        </SelectItem>
-                      );
-                    })}
-                  </SelectContent>
-                </Select>
-                {errors.providerId ? (
-                  <p className="text-sm text-destructive" data-testid={`${testIdPrefix}-provider-error`}>
-                    {errors.providerId}
-                  </p>
-                ) : null}
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor={`${testIdPrefix}-remote`}>Remote Name</Label>
-                <Input
-                  id={`${testIdPrefix}-remote`}
-                  placeholder="<mount>/<path>/<key>"
-                  value={values.remoteName}
-                  onChange={(event) => {
-                    setValues((prev) => ({ ...prev, remoteName: event.target.value }));
-                    clearError('remoteName');
-                  }}
-                  data-testid={`${testIdPrefix}-remote`}
-                />
-                {errors.remoteName ? (
-                  <p className="text-sm text-destructive" data-testid={`${testIdPrefix}-remote-error`}>
-                    {errors.remoteName}
-                  </p>
-                ) : null}
-                <p className="text-xs text-muted-foreground">Format: &lt;mount&gt;/&lt;path&gt;/&lt;key&gt;.</p>
-              </div>
+            <div className="space-y-2">
+              <Label htmlFor={`${testIdPrefix}-remote`}>Remote Name</Label>
+              <Input
+                id={`${testIdPrefix}-remote`}
+                placeholder="<mount>/<path>/<key>"
+                value={values.remoteName}
+                onChange={(event) => {
+                  setValues((prev) => ({ ...prev, remoteName: event.target.value }));
+                  clearError('remoteName');
+                }}
+                data-testid={`${testIdPrefix}-remote`}
+              />
+              {errors.remoteName ? (
+                <p className="text-sm text-destructive" data-testid={`${testIdPrefix}-remote-error`}>
+                  {errors.remoteName}
+                </p>
+              ) : null}
+              <p className="text-xs text-muted-foreground">Format: &lt;mount&gt;/&lt;path&gt;/&lt;key&gt;.</p>
             </div>
           )}
         </div>
@@ -450,7 +427,7 @@ export function OrganizationSecretsTab() {
   });
 
   const handleCreate = (values: SecretFormValues) => {
-    if (values.storageMode === 'local') {
+    if (isBuiltInProviderSelection(values.providerId)) {
       createSecretMutation.mutate({
         title: values.title,
         description: values.description,
@@ -503,11 +480,13 @@ export function OrganizationSecretsTab() {
       description: values.description,
     };
 
-    if (values.storageMode === 'remote') {
+    if (isBuiltInProviderSelection(values.providerId)) {
+      if (values.value) {
+        payload.value = values.value;
+      }
+    } else {
       payload.secretProviderId = values.providerId;
       payload.remoteName = values.remoteName;
-    } else if (values.value) {
-      payload.value = values.value;
     }
 
     updateSecretMutation.mutate(payload);
@@ -545,7 +524,7 @@ export function OrganizationSecretsTab() {
   const getSourceLabel = (secret: Secret) => {
     const storageState = resolveSecretStorageState(secret);
     if (storageState === 'remote') return getProviderLabel(secret.secretProviderId);
-    if (storageState === 'local') return 'Built-in';
+    if (storageState === 'local') return BUILT_IN_PROVIDER_LABEL;
     return 'Invalid configuration';
   };
   const getSourceDetail = (secret: Secret) => {

--- a/src/pages/OrganizationSecretsTab.tsx
+++ b/src/pages/OrganizationSecretsTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { secretsClient } from '@/api/client';
@@ -19,12 +19,313 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import type { Secret } from '@/gen/agynio/api/secrets/v1/secrets_pb';
+import type { Secret, SecretProvider } from '@/gen/agynio/api/secrets/v1/secrets_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useListControls } from '@/hooks/useListControls';
 import { formatDateOnly, timestampToMillis } from '@/lib/format';
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '@/lib/pagination';
 import { toast } from 'sonner';
+
+type StorageMode = 'local' | 'remote';
+
+const STORAGE_MODE_OPTIONS: Array<{ value: StorageMode; label: string }> = [
+  { value: 'local', label: 'Local (built-in)' },
+  { value: 'remote', label: 'Remote provider' },
+];
+
+type SecretFormValues = {
+  title: string;
+  description: string;
+  storageMode: StorageMode;
+  value: string;
+  providerId: string;
+  remoteName: string;
+};
+
+type SecretFormErrors = {
+  title?: string;
+  value?: string;
+  providerId?: string;
+  remoteName?: string;
+};
+
+const DEFAULT_FORM_VALUES: SecretFormValues = {
+  title: '',
+  description: '',
+  storageMode: 'remote',
+  value: '',
+  providerId: '',
+  remoteName: '',
+};
+
+const normalizeSecretFormValues = (values: SecretFormValues): SecretFormValues => ({
+  ...values,
+  title: values.title.trim(),
+  description: values.description.trim(),
+  value: values.value.trim(),
+  remoteName: values.remoteName.trim(),
+});
+
+const isRemoteSecret = (secret: Secret) => Boolean(secret.secretProviderId || secret.remoteName);
+
+const buildFormValuesFromSecret = (secret: Secret | null): SecretFormValues => {
+  if (!secret) return { ...DEFAULT_FORM_VALUES };
+
+  const storageMode: StorageMode = isRemoteSecret(secret) ? 'remote' : 'local';
+
+  return {
+    title: secret.title,
+    description: secret.description,
+    storageMode,
+    value: '',
+    providerId: storageMode === 'remote' ? secret.secretProviderId : '',
+    remoteName: storageMode === 'remote' ? secret.remoteName : '',
+  };
+};
+
+function validateSecretForm(values: SecretFormValues, mode: 'create' | 'edit'): SecretFormErrors {
+  const errors: SecretFormErrors = {};
+
+  if (!values.title.trim()) {
+    errors.title = 'Title is required.';
+  }
+
+  if (values.storageMode === 'local') {
+    if (mode === 'create' && !values.value.trim()) {
+      errors.value = 'Secret value is required.';
+    }
+  } else {
+    if (!values.providerId) {
+      errors.providerId = 'Select a provider.';
+    }
+    if (!values.remoteName.trim()) {
+      errors.remoteName = 'Remote name is required.';
+    }
+  }
+
+  return errors;
+}
+
+type SecretFormDialogProps = {
+  mode: 'create' | 'edit';
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  providers: SecretProvider[];
+  initialValues: SecretFormValues;
+  onSubmit: (values: SecretFormValues) => void;
+  isSubmitting: boolean;
+  storageModeLocked?: boolean;
+};
+
+function SecretFormDialog({
+  mode,
+  open,
+  onOpenChange,
+  providers,
+  initialValues,
+  onSubmit,
+  isSubmitting,
+  storageModeLocked = false,
+}: SecretFormDialogProps) {
+  const [values, setValues] = useState<SecretFormValues>(initialValues);
+  const [errors, setErrors] = useState<SecretFormErrors>({});
+
+  const resolvedInitialValues = useMemo(
+    () => ({ ...DEFAULT_FORM_VALUES, ...initialValues }),
+    [initialValues],
+  );
+
+  useEffect(() => {
+    if (open) {
+      setValues(resolvedInitialValues);
+      setErrors({});
+      return;
+    }
+    setValues({ ...DEFAULT_FORM_VALUES });
+    setErrors({});
+  }, [open, resolvedInitialValues]);
+
+  const testIdPrefix = mode === 'create' ? 'secrets-create' : 'secrets-edit';
+  const dialogTitle = mode === 'create' ? 'Add secret' : 'Edit secret';
+  const dialogDescription =
+    mode === 'create'
+      ? 'Store a secret locally or link it to a provider.'
+      : 'Update secret metadata and storage settings.';
+  const submitLabel = mode === 'create' ? 'Add secret' : 'Save changes';
+  const pendingLabel = mode === 'create' ? 'Adding...' : 'Saving...';
+  const valueLabel = mode === 'create' ? 'Secret Value' : 'New Secret Value';
+  const valuePlaceholder = mode === 'create' ? 'Secret value' : 'Enter a new value';
+
+  const clearError = (field: keyof SecretFormErrors) => {
+    setErrors((prev) => (prev[field] ? { ...prev, [field]: undefined } : prev));
+  };
+
+  const handleStorageModeChange = (nextMode: StorageMode) => {
+    setValues((prev) => ({
+      ...prev,
+      storageMode: nextMode,
+      value: nextMode === 'local' ? prev.value : '',
+      providerId: nextMode === 'remote' ? prev.providerId : '',
+      remoteName: nextMode === 'remote' ? prev.remoteName : '',
+    }));
+    setErrors((prev) => ({
+      ...prev,
+      value: undefined,
+      providerId: undefined,
+      remoteName: undefined,
+    }));
+  };
+
+  const handleSubmit = () => {
+    const normalized = normalizeSecretFormValues(values);
+    const validation = validateSecretForm(normalized, mode);
+    setErrors(validation);
+    if (Object.values(validation).some(Boolean)) return;
+    onSubmit(normalized);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid={`${testIdPrefix}-dialog`}>
+        <DialogHeader>
+          <DialogTitle data-testid={`${testIdPrefix}-title`}>{dialogTitle}</DialogTitle>
+          <DialogDescription data-testid={`${testIdPrefix}-description`}>{dialogDescription}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor={`${testIdPrefix}-title-input`}>Title</Label>
+            <Input
+              id={`${testIdPrefix}-title-input`}
+              value={values.title}
+              onChange={(event) => {
+                setValues((prev) => ({ ...prev, title: event.target.value }));
+                clearError('title');
+              }}
+              data-testid={`${testIdPrefix}-title-input`}
+            />
+            {errors.title ? <p className="text-sm text-destructive">{errors.title}</p> : null}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`${testIdPrefix}-description-input`}>Description</Label>
+            <Input
+              id={`${testIdPrefix}-description-input`}
+              value={values.description}
+              onChange={(event) => setValues((prev) => ({ ...prev, description: event.target.value }))}
+              data-testid={`${testIdPrefix}-description-input`}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`${testIdPrefix}-storage-mode`}>Storage Mode</Label>
+            <Select
+              value={values.storageMode}
+              onValueChange={(value) => handleStorageModeChange(value as StorageMode)}
+              disabled={storageModeLocked}
+            >
+              <SelectTrigger id={`${testIdPrefix}-storage-mode`} data-testid={`${testIdPrefix}-storage-mode`}>
+                <SelectValue placeholder="Select mode" />
+              </SelectTrigger>
+              <SelectContent>
+                {STORAGE_MODE_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {storageModeLocked ? (
+              <p className="text-xs text-muted-foreground">Storage mode cannot be changed after creation.</p>
+            ) : null}
+          </div>
+          {values.storageMode === 'local' ? (
+            <div className="space-y-2">
+              <Label htmlFor={`${testIdPrefix}-value`}>{valueLabel}</Label>
+              <Input
+                id={`${testIdPrefix}-value`}
+                type="password"
+                value={values.value}
+                onChange={(event) => {
+                  setValues((prev) => ({ ...prev, value: event.target.value }));
+                  clearError('value');
+                }}
+                placeholder={valuePlaceholder}
+                data-testid={`${testIdPrefix}-value`}
+              />
+              {errors.value ? (
+                <p className="text-sm text-destructive" data-testid={`${testIdPrefix}-value-error`}>
+                  {errors.value}
+                </p>
+              ) : null}
+              {mode === 'edit' ? (
+                <p className="text-xs text-muted-foreground">Leave blank to keep the existing value.</p>
+              ) : null}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor={`${testIdPrefix}-provider`}>Secret Provider</Label>
+                <Select
+                  value={values.providerId}
+                  onValueChange={(value) => {
+                    setValues((prev) => ({ ...prev, providerId: value }));
+                    clearError('providerId');
+                  }}
+                >
+                  <SelectTrigger id={`${testIdPrefix}-provider`} data-testid={`${testIdPrefix}-provider`}>
+                    <SelectValue placeholder="Select provider" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {providers.map((provider) => {
+                      const providerId = provider.meta?.id;
+                      if (!providerId) return null;
+                      return (
+                        <SelectItem key={providerId} value={providerId}>
+                          {provider.title}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+                {errors.providerId ? (
+                  <p className="text-sm text-destructive" data-testid={`${testIdPrefix}-provider-error`}>
+                    {errors.providerId}
+                  </p>
+                ) : null}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={`${testIdPrefix}-remote`}>Remote Name</Label>
+                <Input
+                  id={`${testIdPrefix}-remote`}
+                  placeholder="secret/data/my-secret"
+                  value={values.remoteName}
+                  onChange={(event) => {
+                    setValues((prev) => ({ ...prev, remoteName: event.target.value }));
+                    clearError('remoteName');
+                  }}
+                  data-testid={`${testIdPrefix}-remote`}
+                />
+                {errors.remoteName ? (
+                  <p className="text-sm text-destructive" data-testid={`${testIdPrefix}-remote-error`}>
+                    {errors.remoteName}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" size="sm" data-testid={`${testIdPrefix}-cancel`}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button size="sm" onClick={handleSubmit} disabled={isSubmitting} data-testid={`${testIdPrefix}-submit`}>
+            {isSubmitting ? pendingLabel : submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 export function OrganizationSecretsTab() {
   useDocumentTitle('Secrets');
@@ -33,22 +334,8 @@ export function OrganizationSecretsTab() {
   const organizationId = id ?? '';
   const queryClient = useQueryClient();
   const [createOpen, setCreateOpen] = useState(false);
-  const [createTitle, setCreateTitle] = useState('');
-  const [createDescription, setCreateDescription] = useState('');
-  const [createProviderId, setCreateProviderId] = useState('');
-  const [createRemoteName, setCreateRemoteName] = useState('');
-  const [createTitleError, setCreateTitleError] = useState('');
-  const [createProviderError, setCreateProviderError] = useState('');
-  const [createRemoteError, setCreateRemoteError] = useState('');
   const [editOpen, setEditOpen] = useState(false);
-  const [editSecretId, setEditSecretId] = useState<string | null>(null);
-  const [editTitle, setEditTitle] = useState('');
-  const [editDescription, setEditDescription] = useState('');
-  const [editProviderId, setEditProviderId] = useState('');
-  const [editRemoteName, setEditRemoteName] = useState('');
-  const [editTitleError, setEditTitleError] = useState('');
-  const [editProviderError, setEditProviderError] = useState('');
-  const [editRemoteError, setEditRemoteError] = useState('');
+  const [editSecret, setEditSecret] = useState<Secret | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const providersQuery = useQuery({
@@ -82,18 +369,12 @@ export function OrganizationSecretsTab() {
       secretProviderId: string;
       remoteName: string;
       organizationId: string;
+      value: string;
     }) => secretsClient.createSecret(payload),
     onSuccess: () => {
       toast.success('Secret created.');
       void queryClient.invalidateQueries({ queryKey: ['secrets', organizationId, 'list'] });
       setCreateOpen(false);
-      setCreateTitle('');
-      setCreateDescription('');
-      setCreateProviderId('');
-      setCreateRemoteName('');
-      setCreateTitleError('');
-      setCreateProviderError('');
-      setCreateRemoteError('');
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : 'Failed to create secret.');
@@ -107,12 +388,13 @@ export function OrganizationSecretsTab() {
       description?: string;
       secretProviderId?: string;
       remoteName?: string;
+      value?: string;
     }) => secretsClient.updateSecret(payload),
     onSuccess: () => {
       toast.success('Secret updated.');
       void queryClient.invalidateQueries({ queryKey: ['secrets', organizationId, 'list'] });
       setEditOpen(false);
-      setEditSecretId(null);
+      setEditSecret(null);
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : 'Failed to update secret.');
@@ -131,54 +413,31 @@ export function OrganizationSecretsTab() {
     },
   });
 
-  const handleCreate = () => {
-    const trimmedTitle = createTitle.trim();
-    const trimmedRemote = createRemoteName.trim();
-    let hasError = false;
+  const handleCreate = (values: SecretFormValues) => {
+    const payload =
+      values.storageMode === 'local'
+        ? {
+            title: values.title,
+            description: values.description,
+            secretProviderId: '',
+            remoteName: '',
+            value: values.value,
+            organizationId,
+          }
+        : {
+            title: values.title,
+            description: values.description,
+            secretProviderId: values.providerId,
+            remoteName: values.remoteName,
+            value: '',
+            organizationId,
+          };
 
-    if (!trimmedTitle) {
-      setCreateTitleError('Title is required.');
-      hasError = true;
-    } else if (createTitleError) {
-      setCreateTitleError('');
-    }
-
-    if (!createProviderId) {
-      setCreateProviderError('Select a provider.');
-      hasError = true;
-    } else if (createProviderError) {
-      setCreateProviderError('');
-    }
-
-    if (!trimmedRemote) {
-      setCreateRemoteError('Remote name is required.');
-      hasError = true;
-    } else if (createRemoteError) {
-      setCreateRemoteError('');
-    }
-
-    if (hasError) return;
-
-    createSecretMutation.mutate({
-      title: trimmedTitle,
-      description: createDescription.trim(),
-      secretProviderId: createProviderId,
-      remoteName: trimmedRemote,
-      organizationId,
-    });
+    createSecretMutation.mutate(payload);
   };
 
   const handleCreateOpenChange = (open: boolean) => {
     setCreateOpen(open);
-    if (!open) {
-      setCreateTitle('');
-      setCreateDescription('');
-      setCreateProviderId('');
-      setCreateRemoteName('');
-      setCreateTitleError('');
-      setCreateProviderError('');
-      setCreateRemoteError('');
-    }
   };
 
   const handleEditOpen = (secret: Secret) => {
@@ -187,69 +446,44 @@ export function OrganizationSecretsTab() {
       toast.error('Missing secret ID.');
       return;
     }
-    setEditSecretId(secretId);
-    setEditTitle(secret.title);
-    setEditDescription(secret.description);
-    setEditProviderId(secret.secretProviderId);
-    setEditRemoteName(secret.remoteName);
-    setEditTitleError('');
-    setEditProviderError('');
-    setEditRemoteError('');
+    setEditSecret(secret);
     setEditOpen(true);
   };
 
-  const handleEditSave = () => {
-    const trimmedTitle = editTitle.trim();
-    const trimmedRemote = editRemoteName.trim();
-    let hasError = false;
-
-    if (!trimmedTitle) {
-      setEditTitleError('Title is required.');
-      hasError = true;
-    } else if (editTitleError) {
-      setEditTitleError('');
-    }
-
-    if (!editProviderId) {
-      setEditProviderError('Select a provider.');
-      hasError = true;
-    } else if (editProviderError) {
-      setEditProviderError('');
-    }
-
-    if (!trimmedRemote) {
-      setEditRemoteError('Remote name is required.');
-      hasError = true;
-    } else if (editRemoteError) {
-      setEditRemoteError('');
-    }
-
-    if (hasError) return;
-    if (!editSecretId) {
+  const handleEditSave = (values: SecretFormValues) => {
+    const secretId = editSecret?.meta?.id;
+    if (!secretId) {
       toast.error('Missing secret ID.');
       return;
     }
 
-    updateSecretMutation.mutate({
-      id: editSecretId,
-      title: trimmedTitle,
-      description: editDescription.trim(),
-      secretProviderId: editProviderId,
-      remoteName: trimmedRemote,
-    });
+    const payload: {
+      id: string;
+      title: string;
+      description: string;
+      secretProviderId?: string;
+      remoteName?: string;
+      value?: string;
+    } = {
+      id: secretId,
+      title: values.title,
+      description: values.description,
+    };
+
+    if (values.storageMode === 'remote') {
+      payload.secretProviderId = values.providerId;
+      payload.remoteName = values.remoteName;
+    } else if (values.value) {
+      payload.value = values.value;
+    }
+
+    updateSecretMutation.mutate(payload);
   };
 
   const handleEditOpenChange = (open: boolean) => {
     setEditOpen(open);
     if (!open) {
-      setEditSecretId(null);
-      setEditTitle('');
-      setEditDescription('');
-      setEditProviderId('');
-      setEditRemoteName('');
-      setEditTitleError('');
-      setEditProviderError('');
-      setEditRemoteError('');
+      setEditSecret(null);
     }
   };
 
@@ -262,22 +496,21 @@ export function OrganizationSecretsTab() {
     setDeleteTargetId(secretId);
   };
 
+  const providers = useMemo(() => providersQuery.data?.secretProviders ?? [], [providersQuery.data?.secretProviders]);
   const providerMap = useMemo(() => {
-    const providers = providersQuery.data?.secretProviders ?? [];
     return new Map(
       providers.flatMap((provider) => {
         const providerId = provider.meta?.id;
         return providerId ? ([[providerId, provider]] as const) : [];
       }),
     );
-  }, [providersQuery.data?.secretProviders]);
-
-  const isLoading = providersQuery.isPending || secretsQuery.isPending;
-  const isError = providersQuery.isError || secretsQuery.isError;
+  }, [providers]);
 
   const secrets = secretsQuery.data?.pages.flatMap((page) => page.secrets) ?? [];
-  const getProviderLabel = (secret: (typeof secrets)[number]) =>
-    providerMap.get(secret.secretProviderId)?.title ?? secret.secretProviderId;
+  const getProviderLabel = (providerId: string) => providerMap.get(providerId)?.title ?? (providerId || 'Remote provider');
+  const getSourceLabel = (secret: Secret) => (isRemoteSecret(secret) ? getProviderLabel(secret.secretProviderId) : 'Built-in');
+  const getSourceDetail = (secret: Secret) =>
+    isRemoteSecret(secret) ? secret.remoteName || '—' : 'Stored in console';
 
   const listControls = useListControls({
     items: secrets,
@@ -285,14 +518,14 @@ export function OrganizationSecretsTab() {
       (secret) => secret.title,
       (secret) => secret.description,
       (secret) => secret.meta?.id ?? '',
-      (secret) => getProviderLabel(secret),
-      (secret) => secret.remoteName,
+      (secret) => getSourceLabel(secret),
+      (secret) => getSourceDetail(secret),
       (secret) => formatDateOnly(secret.meta?.createdAt),
     ],
     sortOptions: {
       title: (secret) => secret.title,
-      provider: (secret) => getProviderLabel(secret),
-      remoteName: (secret) => secret.remoteName,
+      source: (secret) => getSourceLabel(secret),
+      reference: (secret) => getSourceDetail(secret),
       created: (secret) => timestampToMillis(secret.meta?.createdAt),
     },
     defaultSortKey: 'title',
@@ -300,6 +533,9 @@ export function OrganizationSecretsTab() {
 
   const visibleSecrets = listControls.filteredItems;
   const hasSearch = listControls.searchTerm.trim().length > 0;
+  const isLoading = providersQuery.isPending || secretsQuery.isPending;
+  const isError = providersQuery.isError || secretsQuery.isError;
+  const editInitialValues = useMemo(() => buildFormValuesFromSecret(editSecret), [editSecret]);
 
   return (
     <div className="space-y-6">
@@ -325,9 +561,7 @@ export function OrganizationSecretsTab() {
       {isError ? <div className="text-sm text-muted-foreground">Failed to load secrets.</div> : null}
       {secrets.length === 0 && !isLoading ? (
         <Card className="border-border" data-testid="secrets-empty">
-          <CardContent className="py-10 text-center text-sm text-muted-foreground">
-            No secrets configured.
-          </CardContent>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">No secrets configured.</CardContent>
         </Card>
       ) : null}
       {secrets.length > 0 ? (
@@ -345,15 +579,15 @@ export function OrganizationSecretsTab() {
                 onSort={listControls.handleSort}
               />
               <SortableHeader
-                label="Provider"
-                sortKey="provider"
+                label="Source"
+                sortKey="source"
                 activeSortKey={listControls.sortKey}
                 sortDirection={listControls.sortDirection}
                 onSort={listControls.handleSort}
               />
               <SortableHeader
-                label="Remote Name"
-                sortKey="remoteName"
+                label="Reference"
+                sortKey="reference"
                 activeSortKey={listControls.sortKey}
                 sortDirection={listControls.sortDirection}
                 onSort={listControls.handleSort}
@@ -373,52 +607,49 @@ export function OrganizationSecretsTab() {
                   {hasSearch ? 'No results found.' : 'No secrets configured.'}
                 </div>
               ) : (
-                visibleSecrets.map((secret) => {
-                  const provider = providerMap.get(secret.secretProviderId);
-                  return (
-                    <div
-                      key={secret.meta?.id ?? secret.title}
-                      className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_1fr_1fr_140px]"
-                      data-testid="secret-row"
-                    >
-                      <div>
-                        <div className="font-medium" data-testid="secret-title">
-                          {secret.title}
-                        </div>
-                        <div className="text-xs text-muted-foreground" data-testid="secret-id">
-                          {secret.meta?.id ?? '—'}
-                        </div>
+                visibleSecrets.map((secret) => (
+                  <div
+                    key={secret.meta?.id ?? secret.title}
+                    className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_1fr_1fr_140px]"
+                    data-testid="secret-row"
+                  >
+                    <div>
+                      <div className="font-medium" data-testid="secret-title">
+                        {secret.title}
                       </div>
-                      <span className="text-xs text-muted-foreground" data-testid="secret-provider">
-                        {provider?.title ?? secret.secretProviderId}
-                      </span>
-                      <span className="text-xs text-muted-foreground" data-testid="secret-remote">
-                        {secret.remoteName}
-                      </span>
-                      <span className="text-xs text-muted-foreground" data-testid="secret-created">
-                        {formatDateOnly(secret.meta?.createdAt)}
-                      </span>
-                      <div className="flex items-center justify-end gap-2">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => handleEditOpen(secret)}
-                          data-testid="secret-edit"
-                        >
-                          Edit
-                        </Button>
-                        <Button
-                          variant="destructive"
-                          size="sm"
-                          onClick={() => handleDeleteOpen(secret)}
-                          data-testid="secret-delete"
-                        >
-                          Delete
-                        </Button>
+                      <div className="text-xs text-muted-foreground" data-testid="secret-id">
+                        {secret.meta?.id ?? '—'}
                       </div>
                     </div>
-                  );
-                })
+                    <span className="text-xs text-muted-foreground" data-testid="secret-source">
+                      {getSourceLabel(secret)}
+                    </span>
+                    <span className="text-xs text-muted-foreground" data-testid="secret-reference">
+                      {getSourceDetail(secret)}
+                    </span>
+                    <span className="text-xs text-muted-foreground" data-testid="secret-created">
+                      {formatDateOnly(secret.meta?.createdAt)}
+                    </span>
+                    <div className="flex items-center justify-end gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleEditOpen(secret)}
+                        data-testid="secret-edit"
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleDeleteOpen(secret)}
+                        data-testid="secret-delete"
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                ))
               )}
             </div>
           </CardContent>
@@ -431,192 +662,25 @@ export function OrganizationSecretsTab() {
           void secretsQuery.fetchNextPage();
         }}
       />
-      <Dialog open={createOpen} onOpenChange={handleCreateOpenChange}>
-        <DialogContent data-testid="secrets-create-dialog">
-          <DialogHeader>
-            <DialogTitle data-testid="secrets-create-title">Add secret</DialogTitle>
-            <DialogDescription data-testid="secrets-create-description">
-              Register a secret and link it to a provider.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="secrets-create-title-input">Title</Label>
-              <Input
-                id="secrets-create-title-input"
-                value={createTitle}
-                onChange={(event) => {
-                  setCreateTitle(event.target.value);
-                  if (createTitleError) setCreateTitleError('');
-                }}
-                data-testid="secrets-create-title-input"
-              />
-              {createTitleError ? <p className="text-sm text-destructive">{createTitleError}</p> : null}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="secrets-create-description-input">Description</Label>
-              <Input
-                id="secrets-create-description-input"
-                value={createDescription}
-                onChange={(event) => setCreateDescription(event.target.value)}
-                data-testid="secrets-create-description-input"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="secrets-create-provider">Secret Provider</Label>
-              <Select
-                value={createProviderId}
-                onValueChange={(value) => {
-                  setCreateProviderId(value);
-                  if (createProviderError) setCreateProviderError('');
-                }}
-              >
-                <SelectTrigger id="secrets-create-provider" data-testid="secrets-create-provider">
-                  <SelectValue placeholder="Select provider" />
-                </SelectTrigger>
-                <SelectContent>
-                  {(providersQuery.data?.secretProviders ?? []).map((provider) => {
-                    const providerId = provider.meta?.id;
-                    if (!providerId) return null;
-                    return (
-                      <SelectItem key={providerId} value={providerId}>
-                        {provider.title}
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
-              {createProviderError ? (
-                <p className="text-sm text-destructive" data-testid="secrets-create-provider-error">
-                  {createProviderError}
-                </p>
-              ) : null}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="secrets-create-remote">Remote Name</Label>
-              <Input
-                id="secrets-create-remote"
-                placeholder="secret/data/my-secret"
-                value={createRemoteName}
-                onChange={(event) => {
-                  setCreateRemoteName(event.target.value);
-                  if (createRemoteError) setCreateRemoteError('');
-                }}
-                data-testid="secrets-create-remote"
-              />
-              {createRemoteError ? <p className="text-sm text-destructive">{createRemoteError}</p> : null}
-            </div>
-          </div>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button variant="outline" size="sm" data-testid="secrets-create-cancel">
-                Cancel
-              </Button>
-            </DialogClose>
-            <Button
-              size="sm"
-              onClick={handleCreate}
-              disabled={createSecretMutation.isPending}
-              data-testid="secrets-create-submit"
-            >
-              {createSecretMutation.isPending ? 'Adding...' : 'Add secret'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      <Dialog open={editOpen} onOpenChange={handleEditOpenChange}>
-        <DialogContent data-testid="secrets-edit-dialog">
-          <DialogHeader>
-            <DialogTitle data-testid="secrets-edit-title">Edit secret</DialogTitle>
-            <DialogDescription data-testid="secrets-edit-description">
-              Update secret metadata and provider settings.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="secrets-edit-title-input">Title</Label>
-              <Input
-                id="secrets-edit-title-input"
-                value={editTitle}
-                onChange={(event) => {
-                  setEditTitle(event.target.value);
-                  if (editTitleError) setEditTitleError('');
-                }}
-                data-testid="secrets-edit-title-input"
-              />
-              {editTitleError ? <p className="text-sm text-destructive">{editTitleError}</p> : null}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="secrets-edit-description-input">Description</Label>
-              <Input
-                id="secrets-edit-description-input"
-                value={editDescription}
-                onChange={(event) => setEditDescription(event.target.value)}
-                data-testid="secrets-edit-description-input"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="secrets-edit-provider">Secret Provider</Label>
-              <Select
-                value={editProviderId}
-                onValueChange={(value) => {
-                  setEditProviderId(value);
-                  if (editProviderError) setEditProviderError('');
-                }}
-              >
-                <SelectTrigger id="secrets-edit-provider" data-testid="secrets-edit-provider">
-                  <SelectValue placeholder="Select provider" />
-                </SelectTrigger>
-                <SelectContent>
-                  {(providersQuery.data?.secretProviders ?? []).map((provider) => {
-                    const providerId = provider.meta?.id;
-                    if (!providerId) return null;
-                    return (
-                      <SelectItem key={providerId} value={providerId}>
-                        {provider.title}
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
-              {editProviderError ? (
-                <p className="text-sm text-destructive" data-testid="secrets-edit-provider-error">
-                  {editProviderError}
-                </p>
-              ) : null}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="secrets-edit-remote">Remote Name</Label>
-              <Input
-                id="secrets-edit-remote"
-                placeholder="secret/data/my-secret"
-                value={editRemoteName}
-                onChange={(event) => {
-                  setEditRemoteName(event.target.value);
-                  if (editRemoteError) setEditRemoteError('');
-                }}
-                data-testid="secrets-edit-remote"
-              />
-              {editRemoteError ? <p className="text-sm text-destructive">{editRemoteError}</p> : null}
-            </div>
-          </div>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button variant="outline" size="sm" data-testid="secrets-edit-cancel">
-                Cancel
-              </Button>
-            </DialogClose>
-            <Button
-              size="sm"
-              onClick={handleEditSave}
-              disabled={updateSecretMutation.isPending}
-              data-testid="secrets-edit-submit"
-            >
-              {updateSecretMutation.isPending ? 'Saving...' : 'Save changes'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <SecretFormDialog
+        mode="create"
+        open={createOpen}
+        onOpenChange={handleCreateOpenChange}
+        providers={providers}
+        initialValues={DEFAULT_FORM_VALUES}
+        onSubmit={handleCreate}
+        isSubmitting={createSecretMutation.isPending}
+      />
+      <SecretFormDialog
+        mode="edit"
+        open={editOpen}
+        onOpenChange={handleEditOpenChange}
+        providers={providers}
+        initialValues={editInitialValues}
+        onSubmit={handleEditSave}
+        isSubmitting={updateSecretMutation.isPending}
+        storageModeLocked
+      />
       <ConfirmDialog
         open={Boolean(deleteTargetId)}
         onOpenChange={(open) => {

--- a/src/pages/OrganizationSecretsTab.tsx
+++ b/src/pages/OrganizationSecretsTab.tsx
@@ -27,6 +27,7 @@ import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '@/lib/pagination';
 import { toast } from 'sonner';
 
 type StorageMode = 'local' | 'remote';
+type SecretStorageState = StorageMode | 'invalid';
 
 const STORAGE_MODE_OPTIONS: Array<{ value: StorageMode; label: string }> = [
   { value: 'local', label: 'Local (built-in)' },
@@ -49,6 +50,21 @@ type SecretFormErrors = {
   remoteName?: string;
 };
 
+type CreateSecretPayload =
+  | {
+      title: string;
+      description: string;
+      organizationId: string;
+      value: string;
+    }
+  | {
+      title: string;
+      description: string;
+      organizationId: string;
+      secretProviderId: string;
+      remoteName: string;
+    };
+
 const DEFAULT_FORM_VALUES: SecretFormValues = {
   title: '',
   description: '',
@@ -66,12 +82,35 @@ const normalizeSecretFormValues = (values: SecretFormValues): SecretFormValues =
   remoteName: values.remoteName.trim(),
 });
 
-const isRemoteSecret = (secret: Secret) => Boolean(secret.secretProviderId || secret.remoteName);
+const resolveSecretStorageState = (secret: Secret): SecretStorageState => {
+  const providerId = secret.secretProviderId.trim();
+  const remoteName = secret.remoteName.trim();
+  const hasProvider = Boolean(providerId);
+  const hasRemote = Boolean(remoteName);
+
+  if (hasProvider && hasRemote) return 'remote';
+  if (!hasProvider && !hasRemote) return 'local';
+  return 'invalid';
+};
+
+const resolveSecretInvalidReason = (secret: Secret): string => {
+  const hasProvider = Boolean(secret.secretProviderId.trim());
+  const hasRemote = Boolean(secret.remoteName.trim());
+
+  if (hasProvider && !hasRemote) return 'Missing remote name.';
+  if (!hasProvider && hasRemote) return 'Missing provider.';
+  return 'Invalid configuration.';
+};
+
+const resolveFormStorageMode = (secret: Secret): StorageMode => {
+  const state = resolveSecretStorageState(secret);
+  return state === 'remote' || state === 'invalid' ? 'remote' : 'local';
+};
 
 const buildFormValuesFromSecret = (secret: Secret | null): SecretFormValues => {
   if (!secret) return { ...DEFAULT_FORM_VALUES };
 
-  const storageMode: StorageMode = isRemoteSecret(secret) ? 'remote' : 'local';
+  const storageMode = resolveFormStorageMode(secret);
 
   return {
     title: secret.title,
@@ -115,6 +154,7 @@ type SecretFormDialogProps = {
   onSubmit: (values: SecretFormValues) => void;
   isSubmitting: boolean;
   storageModeLocked?: boolean;
+  storageModeNotice?: string;
 };
 
 function SecretFormDialog({
@@ -126,6 +166,7 @@ function SecretFormDialog({
   onSubmit,
   isSubmitting,
   storageModeLocked = false,
+  storageModeNotice,
 }: SecretFormDialogProps) {
   const [values, setValues] = useState<SecretFormValues>(initialValues);
   const [errors, setErrors] = useState<SecretFormErrors>({});
@@ -232,10 +273,11 @@ function SecretFormDialog({
                 ))}
               </SelectContent>
             </Select>
-            {storageModeLocked ? (
-              <p className="text-xs text-muted-foreground">Storage mode cannot be changed after creation.</p>
-            ) : null}
-          </div>
+          {storageModeLocked ? (
+            <p className="text-xs text-muted-foreground">Storage mode cannot be changed after creation.</p>
+          ) : null}
+          {storageModeNotice ? <p className="text-xs text-destructive">{storageModeNotice}</p> : null}
+        </div>
           {values.storageMode === 'local' ? (
             <div className="space-y-2">
               <Label htmlFor={`${testIdPrefix}-value`}>{valueLabel}</Label>
@@ -295,7 +337,7 @@ function SecretFormDialog({
                 <Label htmlFor={`${testIdPrefix}-remote`}>Remote Name</Label>
                 <Input
                   id={`${testIdPrefix}-remote`}
-                  placeholder="secret/data/my-secret"
+                  placeholder="<mount>/<path>/<key>"
                   value={values.remoteName}
                   onChange={(event) => {
                     setValues((prev) => ({ ...prev, remoteName: event.target.value }));
@@ -308,6 +350,7 @@ function SecretFormDialog({
                     {errors.remoteName}
                   </p>
                 ) : null}
+                <p className="text-xs text-muted-foreground">Format: &lt;mount&gt;/&lt;path&gt;/&lt;key&gt;.</p>
               </div>
             </div>
           )}
@@ -363,14 +406,7 @@ export function OrganizationSecretsTab() {
   });
 
   const createSecretMutation = useMutation({
-    mutationFn: (payload: {
-      title: string;
-      description: string;
-      secretProviderId: string;
-      remoteName: string;
-      organizationId: string;
-      value: string;
-    }) => secretsClient.createSecret(payload),
+    mutationFn: (payload: CreateSecretPayload) => secretsClient.createSecret(payload),
     onSuccess: () => {
       toast.success('Secret created.');
       void queryClient.invalidateQueries({ queryKey: ['secrets', organizationId, 'list'] });
@@ -414,26 +450,23 @@ export function OrganizationSecretsTab() {
   });
 
   const handleCreate = (values: SecretFormValues) => {
-    const payload =
-      values.storageMode === 'local'
-        ? {
-            title: values.title,
-            description: values.description,
-            secretProviderId: '',
-            remoteName: '',
-            value: values.value,
-            organizationId,
-          }
-        : {
-            title: values.title,
-            description: values.description,
-            secretProviderId: values.providerId,
-            remoteName: values.remoteName,
-            value: '',
-            organizationId,
-          };
+    if (values.storageMode === 'local') {
+      createSecretMutation.mutate({
+        title: values.title,
+        description: values.description,
+        organizationId,
+        value: values.value,
+      });
+      return;
+    }
 
-    createSecretMutation.mutate(payload);
+    createSecretMutation.mutate({
+      title: values.title,
+      description: values.description,
+      organizationId,
+      secretProviderId: values.providerId,
+      remoteName: values.remoteName,
+    });
   };
 
   const handleCreateOpenChange = (open: boolean) => {
@@ -507,10 +540,20 @@ export function OrganizationSecretsTab() {
   }, [providers]);
 
   const secrets = secretsQuery.data?.pages.flatMap((page) => page.secrets) ?? [];
-  const getProviderLabel = (providerId: string) => providerMap.get(providerId)?.title ?? (providerId || 'Remote provider');
-  const getSourceLabel = (secret: Secret) => (isRemoteSecret(secret) ? getProviderLabel(secret.secretProviderId) : 'Built-in');
-  const getSourceDetail = (secret: Secret) =>
-    isRemoteSecret(secret) ? secret.remoteName || '—' : 'Stored in console';
+  const getProviderLabel = (providerId: string) =>
+    providerId ? providerMap.get(providerId)?.title ?? providerId : '—';
+  const getSourceLabel = (secret: Secret) => {
+    const storageState = resolveSecretStorageState(secret);
+    if (storageState === 'remote') return getProviderLabel(secret.secretProviderId);
+    if (storageState === 'local') return 'Built-in';
+    return 'Invalid configuration';
+  };
+  const getSourceDetail = (secret: Secret) => {
+    const storageState = resolveSecretStorageState(secret);
+    if (storageState === 'remote') return secret.remoteName;
+    if (storageState === 'local') return 'Stored in console';
+    return resolveSecretInvalidReason(secret);
+  };
 
   const listControls = useListControls({
     items: secrets,
@@ -536,6 +579,12 @@ export function OrganizationSecretsTab() {
   const isLoading = providersQuery.isPending || secretsQuery.isPending;
   const isError = providersQuery.isError || secretsQuery.isError;
   const editInitialValues = useMemo(() => buildFormValuesFromSecret(editSecret), [editSecret]);
+  const editStorageNotice = useMemo(() => {
+    if (!editSecret) return undefined;
+    return resolveSecretStorageState(editSecret) === 'invalid'
+      ? `Invalid configuration: ${resolveSecretInvalidReason(editSecret)}`
+      : undefined;
+  }, [editSecret]);
 
   return (
     <div className="space-y-6">
@@ -680,6 +729,7 @@ export function OrganizationSecretsTab() {
         onSubmit={handleEditSave}
         isSubmitting={updateSecretMutation.isPending}
         storageModeLocked
+        storageModeNotice={editStorageNotice}
       />
       <ConfirmDialog
         open={Boolean(deleteTargetId)}

--- a/test/e2e/console-api.ts
+++ b/test/e2e/console-api.ts
@@ -792,6 +792,23 @@ export async function createSecret(
   return secretId;
 }
 
+export async function createLocalSecret(
+  page: Page,
+  opts: { name: string; value: string; organizationId: string },
+): Promise<string> {
+  const response = await postConnect<CreateSecretResponseWire>(page, SECRETS_GATEWAY_PATH, 'CreateSecret', {
+    title: opts.name,
+    description: `E2E local secret for ${opts.name}`,
+    value: opts.value,
+    organizationId: opts.organizationId,
+  });
+  const secretId = response.secret?.meta?.id;
+  if (!secretId) {
+    throw new Error('CreateSecret response missing secret id.');
+  }
+  return secretId;
+}
+
 export async function createImagePullSecret(
   page: Page,
   opts: { organizationId: string; registry: string; username: string; value: string; description?: string },

--- a/test/e2e/organization-secrets.spec.ts
+++ b/test/e2e/organization-secrets.spec.ts
@@ -60,9 +60,31 @@ test('shows local secrets without plaintext', async ({ page }) => {
   await expect(row.getByTestId('secret-source')).toHaveText('Built-in');
   await expect(row.getByTestId('secret-reference')).toHaveText('Stored in console');
   await expect(row).not.toContainText(secretValue);
+  await argosScreenshot(page, 'organization-secrets-local-list');
 
   await row.getByTestId('secret-edit').click();
   const editDialog = page.getByTestId('secrets-edit-dialog');
   await expect(editDialog).toBeVisible({ timeout: 15000 });
   await expect(editDialog.getByTestId('secrets-edit-value')).toHaveValue('');
+  await argosScreenshot(page, 'organization-secrets-local-edit', { fullPage: false });
+});
+
+test('shows secret create dialog storage modes', async ({ page }) => {
+  const organizationId = await createOrganization(page, `e2e-org-secrets-create-${Date.now()}`);
+  await setSelectedOrganization(page, organizationId);
+  await clearOrganizationSecrets(page, organizationId);
+
+  await page.goto(`/organizations/${organizationId}/secrets`);
+  await page.getByTestId('organization-secrets-create').click();
+  const createDialog = page.getByTestId('secrets-create-dialog');
+  await expect(createDialog).toBeVisible({ timeout: 15000 });
+  await expect(createDialog.getByTestId('secrets-create-provider')).toBeVisible({ timeout: 15000 });
+  await expect(createDialog.getByTestId('secrets-create-remote')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'organization-secrets-create-remote', { fullPage: false });
+
+  await createDialog.getByTestId('secrets-create-storage-mode').click();
+  await page.getByRole('option', { name: 'Local (built-in)' }).click();
+  await expect(createDialog.getByTestId('secrets-create-value')).toBeVisible({ timeout: 15000 });
+  await expect(createDialog.getByTestId('secrets-create-value')).toHaveValue('');
+  await argosScreenshot(page, 'organization-secrets-create-local', { fullPage: false });
 });

--- a/test/e2e/organization-secrets.spec.ts
+++ b/test/e2e/organization-secrets.spec.ts
@@ -69,22 +69,29 @@ test('shows local secrets without plaintext', async ({ page }) => {
   await argosScreenshot(page, 'organization-secrets-local-edit', { fullPage: false });
 });
 
-test('shows secret create dialog storage modes', async ({ page }) => {
+test('shows secret create dialog provider selections', async ({ page }) => {
   const organizationId = await createOrganization(page, `e2e-org-secrets-create-${Date.now()}`);
   await setSelectedOrganization(page, organizationId);
   await clearOrganizationSecrets(page, organizationId);
+
+  const providerName = `e2e-provider-${Date.now()}`;
+  await createSecretProvider(page, {
+    organizationId,
+    name: providerName,
+    url: 'https://vault.example.com',
+  });
 
   await page.goto(`/organizations/${organizationId}/secrets`);
   await page.getByTestId('organization-secrets-create').click();
   const createDialog = page.getByTestId('secrets-create-dialog');
   await expect(createDialog).toBeVisible({ timeout: 15000 });
   await expect(createDialog.getByTestId('secrets-create-provider')).toBeVisible({ timeout: 15000 });
-  await expect(createDialog.getByTestId('secrets-create-remote')).toBeVisible({ timeout: 15000 });
-  await argosScreenshot(page, 'organization-secrets-create-remote', { fullPage: false });
-
-  await createDialog.getByTestId('secrets-create-storage-mode').click();
-  await page.getByRole('option', { name: 'Local (built-in)' }).click();
   await expect(createDialog.getByTestId('secrets-create-value')).toBeVisible({ timeout: 15000 });
   await expect(createDialog.getByTestId('secrets-create-value')).toHaveValue('');
-  await argosScreenshot(page, 'organization-secrets-create-local', { fullPage: false });
+  await argosScreenshot(page, 'organization-secrets-create-built-in', { fullPage: false });
+
+  await createDialog.getByTestId('secrets-create-provider').click();
+  await page.getByRole('option', { name: providerName }).click();
+  await expect(createDialog.getByTestId('secrets-create-remote')).toBeVisible({ timeout: 15000 });
+  await argosScreenshot(page, 'organization-secrets-create-remote', { fullPage: false });
 });

--- a/test/e2e/organization-secrets.spec.ts
+++ b/test/e2e/organization-secrets.spec.ts
@@ -2,6 +2,7 @@ import { argosScreenshot } from '@argos-ci/playwright';
 import { test, expect } from './fixtures';
 import {
   clearOrganizationSecrets,
+  createLocalSecret,
   createOrganization,
   createSecret,
   createSecretProvider,
@@ -42,4 +43,26 @@ test('shows secret providers and secrets', async ({ page }) => {
   await page.goto(`/organizations/${organizationId}/secrets`);
   await expect(page.getByTestId('secret-row').filter({ hasText: secretName })).toBeVisible({ timeout: 15000 });
   await argosScreenshot(page, 'organization-secrets-list');
+});
+
+test('shows local secrets without plaintext', async ({ page }) => {
+  const organizationId = await createOrganization(page, `e2e-org-secrets-local-${Date.now()}`);
+  await setSelectedOrganization(page, organizationId);
+  await clearOrganizationSecrets(page, organizationId);
+
+  const secretName = `e2e-local-secret-${Date.now()}`;
+  const secretValue = `e2e-local-value-${Date.now()}`;
+  await createLocalSecret(page, { name: secretName, value: secretValue, organizationId });
+
+  await page.goto(`/organizations/${organizationId}/secrets`);
+  const row = page.getByTestId('secret-row').filter({ hasText: secretName });
+  await expect(row).toBeVisible({ timeout: 15000 });
+  await expect(row.getByTestId('secret-source')).toHaveText('Built-in');
+  await expect(row.getByTestId('secret-reference')).toHaveText('Stored in console');
+  await expect(row).not.toContainText(secretValue);
+
+  await row.getByTestId('secret-edit').click();
+  const editDialog = page.getByTestId('secrets-edit-dialog');
+  await expect(editDialog).toBeVisible({ timeout: 15000 });
+  await expect(editDialog.getByTestId('secrets-edit-value')).toHaveValue('');
 });


### PR DESCRIPTION
## Summary
- add storage mode selection for secrets create/edit with local value handling
- prevent plaintext display by keeping local values masked/empty after creation
- update secrets list to show source and reference for local vs remote

## Testing
- npm run lint
- npm run test
- npm run typecheck
- npm run build

Fixes #73