### PR TITLE
fix: show running workloads as started

### DIFF
--- a/src/__tests__/format-workload-status.test.ts
+++ b/src/__tests__/format-workload-status.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { WorkloadStatus } from '@/gen/agynio/api/runners/v1/runners_pb';
+import { formatWorkloadStatus } from '@/lib/format';
+
+describe('formatWorkloadStatus', () => {
+  it('formats starting status', () => {
+    expect(formatWorkloadStatus(WorkloadStatus.STARTING)).toBe('Starting');
+  });
+
+  it('formats running status as started', () => {
+    expect(formatWorkloadStatus(WorkloadStatus.RUNNING)).toBe('Started');
+  });
+
+  it('formats stopping status', () => {
+    expect(formatWorkloadStatus(WorkloadStatus.STOPPING)).toBe('Stopping');
+  });
+
+  it('formats stopped status', () => {
+    expect(formatWorkloadStatus(WorkloadStatus.STOPPED)).toBe('Stopped');
+  });
+
+  it('formats failed status', () => {
+    expect(formatWorkloadStatus(WorkloadStatus.FAILED)).toBe('Failed');
+  });
+
+  it('formats unspecified status', () => {
+    expect(formatWorkloadStatus(WorkloadStatus.UNSPECIFIED)).toBe('Unspecified');
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -107,7 +107,7 @@ export function formatDeviceStatus(status: DeviceStatus): string {
 
 export function formatWorkloadStatus(status: WorkloadStatus): string {
   if (status === WorkloadStatus.STARTING) return 'Starting';
-  if (status === WorkloadStatus.RUNNING) return 'Running';
+  if (status === WorkloadStatus.RUNNING) return 'Started';
   if (status === WorkloadStatus.STOPPING) return 'Stopping';
   if (status === WorkloadStatus.STOPPED) return 'Stopped';
   if (status === WorkloadStatus.FAILED) return 'Failed';


### PR DESCRIPTION
## Summary
- Change `WorkloadStatus.RUNNING` display text from `Running` to `Started`.
- Add formatter unit tests covering workload status labels.

Fixes #95

## Test & Lint Summary
Commands run:
- `npm run generate`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

Results:
- Tests: 72 passed, 0 failed, 0 skipped.
- Lint: passed with no errors.
- Typecheck: passed.
- Build: passed.