### PR TITLE
fix: generate API from published module

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,8 +1,6 @@
 version: v2
 inputs:
-  - git_repo: https://github.com/agynio/api.git
-    branch: noa/issue-51-agent-availability
-    subdir: proto
+  - module: buf.build/agynio/api
     paths:
       - agynio/api/gateway/v1
       - agynio/api/agents/v1


### PR DESCRIPTION
## Summary
- switch `buf.gen.yaml` back to the published `buf.build/agynio/api` module now that the API contract is available
- avoid requiring `git` inside the Docker build image for `npm run generate`

Fixes #98

## Validation
- `nix shell nixpkgs#nodejs_20 -c sh -c 'npm ci && npm run generate && npm run lint && npm run typecheck && npm run test && npm run build'`
  - Tests: 72 passed, 0 failed, 0 skipped across 18 files
  - Lint: passed with no errors
- `nix shell nixpkgs#docker-buildx -c docker-buildx build --progress=plain --target build -t console-app-release-fix:test .`
  - Docker build target passed; `npm run generate` and `npm run build` completed in the image