### PR TITLE
Clarify private agent sharing roles

### DIFF
--- a/src/__tests__/agent-roles-section.test.tsx
+++ b/src/__tests__/agent-roles-section.test.tsx
@@ -85,6 +85,17 @@ function buildUser(identityId: string, username: string, name: string, email: st
   });
 }
 
+function mockMembersPages(pages: Array<{ memberships: ReturnType<typeof buildMembership>[]; nextPageToken?: string }>) {
+  listMembers.mockImplementation(({ pageToken }: { pageToken: string }) => {
+    const pageIndex = pageToken ? Number(pageToken) : 0;
+    const page = pages[pageIndex];
+    return Promise.resolve({
+      memberships: page.memberships,
+      nextPageToken: page.nextPageToken ?? '',
+    });
+  });
+}
+
 async function openSelect(testId: string) {
   fireEvent.click(screen.getByTestId(testId));
   return screen.findByRole('listbox');
@@ -109,9 +120,9 @@ describe('AgentRolesSection', () => {
     listAgentRoles.mockResolvedValue({
       assignments: [buildAssignment('identity-owner', AgentRole.OWNER)],
     });
-    listMembers.mockResolvedValue({
-      memberships: [buildMembership('identity-owner'), buildMembership('identity-new')],
-    });
+    mockMembersPages([
+      { memberships: [buildMembership('identity-owner'), buildMembership('identity-new')] },
+    ]);
     batchGetUsers.mockResolvedValue({
       users: [
         buildUser('identity-owner', 'owner-user', 'Owner User', 'owner@example.com'),
@@ -161,6 +172,53 @@ describe('AgentRolesSection', () => {
       expect(setAgentRole).toHaveBeenCalledWith({
         agentId: 'agent-1',
         identityId: 'identity-new',
+        role: AgentRole.PARTICIPANT,
+      });
+    });
+  });
+
+  it('loads every page of organization members for the picker', async () => {
+    mockMembersPages([
+      { memberships: [buildMembership('identity-owner')], nextPageToken: '1' },
+      { memberships: [buildMembership('identity-later')] },
+    ]);
+    batchGetUsers.mockResolvedValue({
+      users: [
+        buildUser('identity-owner', 'owner-user', 'Owner User', 'owner@example.com'),
+        buildUser('identity-later', 'later-user', 'Later User', 'later@example.com'),
+      ],
+    });
+    setAgentRole.mockResolvedValue({ assignment: buildAssignment('identity-later', AgentRole.PARTICIPANT) });
+
+    renderSection();
+
+    fireEvent.click(screen.getByTestId('agent-roles-add'));
+    expect(await screen.findByTestId('agent-roles-dialog')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(listMembers).toHaveBeenCalledTimes(2);
+    });
+    expect(listMembers).toHaveBeenNthCalledWith(1, {
+      organizationId: 'org-1',
+      status: MembershipStatus.ACTIVE,
+      pageSize: 200,
+      pageToken: '',
+    });
+    expect(listMembers).toHaveBeenNthCalledWith(2, {
+      organizationId: 'org-1',
+      status: MembershipStatus.ACTIVE,
+      pageSize: 200,
+      pageToken: '1',
+    });
+
+    const memberListbox = await openSelect('agent-roles-member');
+    fireEvent.click(within(memberListbox).getByText('@later-user'));
+    fireEvent.click(screen.getByTestId('agent-roles-save'));
+
+    await waitFor(() => {
+      expect(setAgentRole).toHaveBeenCalledWith({
+        agentId: 'agent-1',
+        identityId: 'identity-later',
         role: AgentRole.PARTICIPANT,
       });
     });

--- a/src/__tests__/agent-roles-section.test.tsx
+++ b/src/__tests__/agent-roles-section.test.tsx
@@ -1,0 +1,211 @@
+import { create } from '@bufbuild/protobuf';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { AgentAvailability, AgentRole, AgentRoleAssignmentSchema } from '@/gen/agynio/api/agents/v1/agents_pb';
+import {
+  MembershipRole,
+  MembershipSchema,
+  MembershipStatus,
+} from '@/gen/agynio/api/organizations/v1/organizations_pb';
+import { EntityMetaSchema, UserSchema } from '@/gen/agynio/api/users/v1/users_pb';
+import { AgentRolesSection } from '@/pages/agent-detail/AgentRolesSection';
+
+const { listAgentRoles, setAgentRole, removeAgentRole } = vi.hoisted(() => ({
+  listAgentRoles: vi.fn(),
+  setAgentRole: vi.fn(),
+  removeAgentRole: vi.fn(),
+}));
+
+const { listMembers } = vi.hoisted(() => ({
+  listMembers: vi.fn(),
+}));
+
+const { batchGetUsers } = vi.hoisted(() => ({
+  batchGetUsers: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  agentsClient: {
+    listAgentRoles,
+    setAgentRole,
+    removeAgentRole,
+  },
+  organizationsClient: {
+    listMembers,
+  },
+  usersClient: {
+    batchGetUsers,
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function renderSection(availability = AgentAvailability.PRIVATE) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentRolesSection agentId="agent-1" organizationId="org-1" availability={availability} />
+    </QueryClientProvider>,
+  );
+}
+
+function buildAssignment(identityId: string, role: AgentRole) {
+  return create(AgentRoleAssignmentSchema, {
+    agentId: 'agent-1',
+    identityId,
+    role,
+  });
+}
+
+function buildMembership(identityId: string) {
+  return create(MembershipSchema, {
+    id: `membership-${identityId}`,
+    organizationId: 'org-1',
+    identityId,
+    role: MembershipRole.MEMBER,
+    status: MembershipStatus.ACTIVE,
+  });
+}
+
+function buildUser(identityId: string, username: string, name: string, email: string) {
+  return create(UserSchema, {
+    meta: create(EntityMetaSchema, { id: identityId }),
+    username,
+    name,
+    email,
+  });
+}
+
+async function openSelect(testId: string) {
+  fireEvent.click(screen.getByTestId(testId));
+  return screen.findByRole('listbox');
+}
+
+describe('AgentRolesSection', () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    listAgentRoles.mockReset();
+    setAgentRole.mockReset();
+    removeAgentRole.mockReset();
+    listMembers.mockReset();
+    batchGetUsers.mockReset();
+
+    listAgentRoles.mockResolvedValue({
+      assignments: [buildAssignment('identity-owner', AgentRole.OWNER)],
+    });
+    listMembers.mockResolvedValue({
+      memberships: [buildMembership('identity-owner'), buildMembership('identity-new')],
+    });
+    batchGetUsers.mockResolvedValue({
+      users: [
+        buildUser('identity-owner', 'owner-user', 'Owner User', 'owner@example.com'),
+        buildUser('identity-new', 'new-user', 'New User', 'new@example.com'),
+      ],
+    });
+    setAgentRole.mockResolvedValue({ assignment: buildAssignment('identity-new', AgentRole.PARTICIPANT) });
+    removeAgentRole.mockResolvedValue({});
+  });
+
+  it('makes specific-user private sharing discoverable', async () => {
+    renderSection(AgentAvailability.PRIVATE);
+
+    expect(screen.getByText('Share with specific users')).toBeTruthy();
+    expect(screen.getByText('Private sharing active')).toBeTruthy();
+    expect(screen.getByText(/Private agents are shared by assigning owner, maintainer, or participant roles/i)).toBeTruthy();
+
+    expect(await screen.findByText('@owner-user')).toBeTruthy();
+    expect(screen.getByText('identity-owner')).toBeTruthy();
+    expect(screen.getByText('Owner')).toBeTruthy();
+  });
+
+  it('explains the availability interaction before the agent is private', async () => {
+    renderSection(AgentAvailability.INTERNAL);
+
+    expect(screen.getByText('Share with specific users')).toBeTruthy();
+    expect(screen.getByText('Available when Private')).toBeTruthy();
+    expect(screen.getByTestId('agent-roles-private-hint').textContent).toContain('set Availability to Private');
+    expect(await screen.findByText('@owner-user')).toBeTruthy();
+  });
+
+  it('adds a role assignment for an organization member', async () => {
+    renderSection();
+
+    fireEvent.click(screen.getByTestId('agent-roles-add'));
+    expect(await screen.findByTestId('agent-roles-dialog')).toBeTruthy();
+
+    const memberListbox = await openSelect('agent-roles-member');
+    fireEvent.click(within(memberListbox).getByText('identity-new'));
+
+    const roleListbox = await openSelect('agent-roles-role');
+    fireEvent.click(within(roleListbox).getByText('Participant'));
+
+    fireEvent.click(screen.getByTestId('agent-roles-save'));
+
+    await waitFor(() => {
+      expect(setAgentRole).toHaveBeenCalledWith({
+        agentId: 'agent-1',
+        identityId: 'identity-new',
+        role: AgentRole.PARTICIPANT,
+      });
+    });
+  });
+
+  it('changes an existing role assignment', async () => {
+    renderSection();
+
+    fireEvent.click(await screen.findByTestId('agent-roles-change'));
+    expect(await screen.findByTestId('agent-roles-dialog')).toBeTruthy();
+
+    const roleListbox = await openSelect('agent-roles-role');
+    fireEvent.click(within(roleListbox).getByText('Maintainer'));
+    fireEvent.click(screen.getByTestId('agent-roles-save'));
+
+    await waitFor(() => {
+      expect(setAgentRole).toHaveBeenCalledWith({
+        agentId: 'agent-1',
+        identityId: 'identity-owner',
+        role: AgentRole.MAINTAINER,
+      });
+    });
+  });
+
+  it('removes a role assignment', async () => {
+    renderSection();
+
+    fireEvent.click(await screen.findByTestId('agent-roles-remove'));
+
+    await waitFor(() => {
+      expect(removeAgentRole).toHaveBeenCalledWith({ agentId: 'agent-1', identityId: 'identity-owner' });
+    });
+  });
+
+  it('shows a permission error when role management is denied', async () => {
+    setAgentRole.mockRejectedValueOnce(new ConnectError('permission denied', Code.PermissionDenied));
+    renderSection();
+
+    fireEvent.click(screen.getByTestId('agent-roles-add'));
+    expect(await screen.findByTestId('agent-roles-dialog')).toBeTruthy();
+
+    const memberListbox = await openSelect('agent-roles-member');
+    fireEvent.click(within(memberListbox).getByText('identity-new'));
+    fireEvent.click(screen.getByTestId('agent-roles-save'));
+
+    expect((await screen.findByTestId('agent-roles-error')).textContent).toBe('You do not have permission to manage agent sharing roles.');
+  });
+});

--- a/src/pages/AgentDetailPage.tsx
+++ b/src/pages/AgentDetailPage.tsx
@@ -77,7 +77,7 @@ export function AgentDetailPage() {
             <AgentConfigurationTab agent={agent} organizationId={organizationId} />
           </section>
           <section data-testid="agent-detail-section-roles">
-            <AgentRolesSection agentId={resolvedAgentId} organizationId={organizationId} />
+            <AgentRolesSection agentId={resolvedAgentId} organizationId={organizationId} availability={agent.availability} />
           </section>
           <section data-testid="agent-detail-section-mcps">
             <AgentMcpsTab agentId={resolvedAgentId} organizationId={organizationId} />

--- a/src/pages/agent-detail/AgentRolesSection.tsx
+++ b/src/pages/agent-detail/AgentRolesSection.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { Code, ConnectError } from '@connectrpc/connect';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { agentsClient, organizationsClient, usersClient } from '@/api/client';
 import { Button } from '@/components/ui/button';
@@ -15,7 +16,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { AgentRole, type AgentRoleAssignment } from '@/gen/agynio/api/agents/v1/agents_pb';
+import { AgentAvailability, AgentRole, type AgentRoleAssignment } from '@/gen/agynio/api/agents/v1/agents_pb';
 import { MembershipStatus } from '@/gen/agynio/api/organizations/v1/organizations_pb';
 import { formatAgentRole } from '@/lib/format';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
@@ -24,15 +25,24 @@ import { toast } from 'sonner';
 type AgentRolesSectionProps = {
   agentId: string;
   organizationId: string;
+  availability: AgentAvailability;
 };
 
 const assignableRoles = [AgentRole.OWNER, AgentRole.MAINTAINER, AgentRole.PARTICIPANT] as const;
 
-export function AgentRolesSection({ agentId, organizationId }: AgentRolesSectionProps) {
+function formatRoleError(error: unknown, fallback: string) {
+  if (error instanceof ConnectError && error.code === Code.PermissionDenied) {
+    return 'You do not have permission to manage agent sharing roles.';
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
+export function AgentRolesSection({ agentId, organizationId, availability }: AgentRolesSectionProps) {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedIdentityId, setSelectedIdentityId] = useState('');
   const [selectedRole, setSelectedRole] = useState<AgentRole>(AgentRole.PARTICIPANT);
+  const [roleError, setRoleError] = useState('');
 
   const rolesQuery = useQuery({
     queryKey: ['agents', agentId, 'roles'],
@@ -57,9 +67,18 @@ export function AgentRolesSection({ agentId, organizationId }: AgentRolesSection
   });
 
   const assignments = useMemo(() => rolesQuery.data?.assignments ?? [], [rolesQuery.data?.assignments]);
+  const members = useMemo(() => membersQuery.data?.memberships ?? [], [membersQuery.data?.memberships]);
   const identityIds = useMemo(
-    () => Array.from(new Set(assignments.map((assignment) => assignment.identityId).filter(Boolean))),
-    [assignments],
+    () =>
+      Array.from(
+        new Set(
+          [
+            ...assignments.map((assignment) => assignment.identityId),
+            ...members.map((membership) => membership.identityId),
+          ].filter(Boolean),
+        ),
+      ),
+    [assignments, members],
   );
 
   const usersQuery = useQuery({
@@ -80,7 +99,6 @@ export function AgentRolesSection({ agentId, organizationId }: AgentRolesSection
     );
   }, [usersQuery.data?.users]);
 
-  const members = membersQuery.data?.memberships ?? [];
   const roleByIdentityId = useMemo(
     () => new Map(assignments.map((assignment) => [assignment.identityId, assignment.role] as const)),
     [assignments],
@@ -95,9 +113,12 @@ export function AgentRolesSection({ agentId, organizationId }: AgentRolesSection
       setDialogOpen(false);
       setSelectedIdentityId('');
       setSelectedRole(AgentRole.PARTICIPANT);
+      setRoleError('');
     },
     onError: (error) => {
-      toast.error(error instanceof Error ? error.message : 'Failed to save agent role.');
+      const message = formatRoleError(error, 'Failed to save agent role.');
+      setRoleError(message);
+      toast.error(message);
     },
   });
 
@@ -106,9 +127,12 @@ export function AgentRolesSection({ agentId, organizationId }: AgentRolesSection
     onSuccess: () => {
       toast.success('Agent role removed.');
       void queryClient.invalidateQueries({ queryKey: ['agents', agentId, 'roles'] });
+      setRoleError('');
     },
     onError: (error) => {
-      toast.error(error instanceof Error ? error.message : 'Failed to remove agent role.');
+      const message = formatRoleError(error, 'Failed to remove agent role.');
+      setRoleError(message);
+      toast.error(message);
     },
   });
 
@@ -120,25 +144,57 @@ export function AgentRolesSection({ agentId, organizationId }: AgentRolesSection
   const openEdit = (assignment?: AgentRoleAssignment) => {
     setSelectedIdentityId(assignment?.identityId ?? '');
     setSelectedRole(assignment?.role || AgentRole.PARTICIPANT);
+    setRoleError('');
     setDialogOpen(true);
   };
 
+  const sharingDescription =
+    availability === AgentAvailability.PRIVATE
+      ? 'Private agents are shared by assigning owner, maintainer, or participant roles to specific organization members.'
+      : 'Assign roles now to prepare specific-user sharing before switching this agent to Private availability.';
+
   return (
-    <Card className="border-border" data-testid="agent-roles-card">
+    <Card className="border-primary/40 bg-primary/5" data-testid="agent-roles-card">
       <CardContent className="space-y-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h3 className="text-lg font-semibold text-foreground">Roles</h3>
-            <p className="text-sm text-muted-foreground">Per-agent access for organization members.</p>
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-lg font-semibold text-foreground">Share with specific users</h3>
+              <Badge variant={availability === AgentAvailability.PRIVATE ? 'default' : 'outline'} data-testid="agent-roles-availability">
+                {availability === AgentAvailability.PRIVATE ? 'Private sharing active' : 'Available when Private'}
+              </Badge>
+            </div>
+            <p className="max-w-2xl text-sm text-muted-foreground">{sharingDescription}</p>
           </div>
           <Button variant="outline" size="sm" onClick={() => openEdit()} data-testid="agent-roles-add">
-            Add role
+            Share agent
           </Button>
         </div>
+        {availability !== AgentAvailability.PRIVATE ? (
+          <div className="rounded-md border border-border bg-background p-3 text-sm text-muted-foreground" data-testid="agent-roles-private-hint">
+            To limit thread access to only the users listed here, set Availability to Private in Configuration.
+          </div>
+        ) : null}
         {rolesQuery.isPending ? <div className="text-sm text-muted-foreground">Loading roles...</div> : null}
-        {rolesQuery.isError ? <div className="text-sm text-muted-foreground">Failed to load roles.</div> : null}
+        {rolesQuery.isError ? (
+          <div className="text-sm text-destructive" data-testid="agent-roles-load-error">
+            {formatRoleError(rolesQuery.error, 'Failed to load sharing roles.')}
+          </div>
+        ) : null}
+        {membersQuery.isError ? (
+          <div className="text-sm text-destructive" data-testid="agent-roles-members-error">
+            Failed to load organization members for sharing.
+          </div>
+        ) : null}
+        {roleError ? (
+          <div className="text-sm text-destructive" data-testid="agent-roles-error">
+            {roleError}
+          </div>
+        ) : null}
         {assignments.length === 0 && !rolesQuery.isPending ? (
-          <div className="text-sm text-muted-foreground">No explicit roles assigned.</div>
+          <div className="text-sm text-muted-foreground" data-testid="agent-roles-empty">
+            No users are explicitly shared on this agent yet.
+          </div>
         ) : null}
         {assignments.length > 0 ? (
           <div className="divide-y divide-border rounded-md border border-border" data-testid="agent-roles-list">
@@ -150,7 +206,7 @@ export function AgentRolesSection({ agentId, organizationId }: AgentRolesSection
                 </div>
                 <div className="flex items-center gap-2">
                   <Badge variant="secondary">{formatAgentRole(assignment.role)}</Badge>
-                  <Button variant="outline" size="sm" onClick={() => openEdit(assignment)}>
+                  <Button variant="outline" size="sm" onClick={() => openEdit(assignment)} data-testid="agent-roles-change">
                     Change
                   </Button>
                   <Button
@@ -158,6 +214,7 @@ export function AgentRolesSection({ agentId, organizationId }: AgentRolesSection
                     size="sm"
                     onClick={() => removeRoleMutation.mutate(assignment.identityId)}
                     disabled={removeRoleMutation.isPending}
+                    data-testid="agent-roles-remove"
                   >
                     Remove
                   </Button>
@@ -170,8 +227,10 @@ export function AgentRolesSection({ agentId, organizationId }: AgentRolesSection
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent data-testid="agent-roles-dialog">
           <DialogHeader>
-            <DialogTitle>Agent role</DialogTitle>
-            <DialogDescription>Select an organization member and their role on this agent.</DialogDescription>
+            <DialogTitle>Share private agent</DialogTitle>
+            <DialogDescription>
+              Select an organization member who can use this agent when Availability is Private.
+            </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-2">
@@ -181,6 +240,7 @@ export function AgentRolesSection({ agentId, organizationId }: AgentRolesSection
                   <SelectValue placeholder="Select member" />
                 </SelectTrigger>
                 <SelectContent>
+                  {membersQuery.isPending ? <SelectItem value="loading" disabled>Loading members...</SelectItem> : null}
                   {members.map((membership) => (
                     <SelectItem key={membership.identityId} value={membership.identityId}>
                       {memberLabel(membership.identityId)}
@@ -216,6 +276,7 @@ export function AgentRolesSection({ agentId, organizationId }: AgentRolesSection
               size="sm"
               onClick={() => setRoleMutation.mutate({ identityId: selectedIdentityId, role: selectedRole })}
               disabled={!selectedIdentityId || setRoleMutation.isPending}
+              data-testid="agent-roles-save"
             >
               {setRoleMutation.isPending ? 'Saving...' : 'Save role'}
             </Button>

--- a/src/pages/agent-detail/AgentRolesSection.tsx
+++ b/src/pages/agent-detail/AgentRolesSection.tsx
@@ -17,7 +17,7 @@ import {
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AgentAvailability, AgentRole, type AgentRoleAssignment } from '@/gen/agynio/api/agents/v1/agents_pb';
-import { MembershipStatus } from '@/gen/agynio/api/organizations/v1/organizations_pb';
+import { MembershipStatus, type Membership } from '@/gen/agynio/api/organizations/v1/organizations_pb';
 import { formatAgentRole } from '@/lib/format';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
 import { toast } from 'sonner';
@@ -29,6 +29,24 @@ type AgentRolesSectionProps = {
 };
 
 const assignableRoles = [AgentRole.OWNER, AgentRole.MAINTAINER, AgentRole.PARTICIPANT] as const;
+
+async function listActiveOrganizationMembers(organizationId: string): Promise<Membership[]> {
+  const memberships: Membership[] = [];
+  let pageToken = '';
+
+  do {
+    const response = await organizationsClient.listMembers({
+      organizationId,
+      status: MembershipStatus.ACTIVE,
+      pageSize: MAX_PAGE_SIZE,
+      pageToken,
+    });
+    memberships.push(...response.memberships);
+    pageToken = response.nextPageToken;
+  } while (pageToken);
+
+  return memberships;
+}
 
 function formatRoleError(error: unknown, fallback: string) {
   if (error instanceof ConnectError && error.code === Code.PermissionDenied) {
@@ -54,20 +72,14 @@ export function AgentRolesSection({ agentId, organizationId, availability }: Age
 
   const membersQuery = useQuery({
     queryKey: ['organizations', organizationId, 'members', 'roles-picker'],
-    queryFn: () =>
-      organizationsClient.listMembers({
-        organizationId,
-        status: MembershipStatus.ACTIVE,
-        pageSize: MAX_PAGE_SIZE,
-        pageToken: '',
-      }),
+    queryFn: () => listActiveOrganizationMembers(organizationId),
     enabled: Boolean(organizationId),
     staleTime: 60_000,
     refetchOnWindowFocus: false,
   });
 
   const assignments = useMemo(() => rolesQuery.data?.assignments ?? [], [rolesQuery.data?.assignments]);
-  const members = useMemo(() => membersQuery.data?.memberships ?? [], [membersQuery.data?.memberships]);
+  const members = useMemo(() => membersQuery.data ?? [], [membersQuery.data]);
   const identityIds = useMemo(
     () =>
       Array.from(


### PR DESCRIPTION
## Summary
- Relabel the agent Roles section as "Share with specific users" and highlight how it controls private-agent access.
- Thread the agent availability into the roles section so private agents show active sharing state and internal agents show a clear "set Availability to Private" hint.
- Improve role-management error UX for permission-denied responses.
- Add component coverage for role list/discoverability, add, change, remove, availability hint, and permission errors.

## Verification
- Confirmed current behavior: `AgentRolesSection` was already rendered on `AgentDetailPage`, but the generic "Roles" label made private-agent sharing hard to discover.
- `npm run test`: 19 files passed, 78 tests passed, 0 failed, 0 skipped.
- `npm run lint`: passed with no errors or warnings.
- `npm run typecheck`: passed.
- `npm run build`: passed.

Closes #100