### PR TITLE
fix: add tooltip provider at app root

### DIFF
--- a/src/__tests__/organization-runners-tab.test.tsx
+++ b/src/__tests__/organization-runners-tab.test.tsx
@@ -1,0 +1,103 @@
+import { create } from '@bufbuild/protobuf';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { PageTitleProvider } from '@/context/PageTitleContext';
+import type { useUserContext } from '@/context/UserContext';
+import {
+  EntityMetaSchema,
+  RunnerSchema,
+  RunnerStatus,
+} from '@/gen/agynio/api/runners/v1/runners_pb';
+import { DEFAULT_PAGE_SIZE } from '@/lib/pagination';
+import { OrganizationRunnersTab } from '@/pages/OrganizationRunnersTab';
+
+type UserContextValue = ReturnType<typeof useUserContext>;
+
+const { listRunners } = vi.hoisted(() => ({
+  listRunners: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  runnersClient: {
+    listRunners,
+  },
+}));
+
+let userContext: UserContextValue;
+
+vi.mock('@/context/UserContext', () => ({
+  useUserContext: () => userContext,
+}));
+
+function renderRunnersTab() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <PageTitleProvider>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={['/organizations/org-1/runners']}>
+            <Routes>
+              <Route path="/organizations/:id/runners" element={<OrganizationRunnersTab />} />
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </PageTitleProvider>,
+  );
+}
+
+describe('OrganizationRunnersTab', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    userContext = {
+      currentUser: null,
+      clusterRole: null,
+      identityId: 'identity-1',
+      isClusterAdmin: false,
+      status: 'ready',
+      error: null,
+      signOut: vi.fn(),
+    };
+
+    listRunners.mockReset();
+  });
+
+  it('renders cluster runners for non-admins with disabled view action', async () => {
+    listRunners.mockResolvedValue({
+      runners: [
+        create(RunnerSchema, {
+          meta: create(EntityMetaSchema, { id: 'cluster-runner-1' }),
+          name: 'cluster-runner',
+          status: RunnerStatus.ENROLLED,
+          labels: { scope: 'cluster' },
+        }),
+      ],
+      nextPageToken: '',
+    });
+
+    expect(() => renderRunnersTab()).not.toThrow();
+
+    expect(await screen.findByText('cluster-runner')).toBeTruthy();
+    const viewButton = screen.getByTestId('organization-cluster-runner-view');
+
+    expect(viewButton).toBeInstanceOf(HTMLButtonElement);
+    expect((viewButton as HTMLButtonElement).disabled).toBe(true);
+
+    await waitFor(() => {
+      expect(listRunners).toHaveBeenCalledWith({
+        organizationId: 'org-1',
+        pageSize: DEFAULT_PAGE_SIZE,
+        pageToken: '',
+      });
+    });
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthGate } from '@/auth';
 import { ThemeProvider } from '@/components/theme-provider';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { OrganizationProvider } from '@/context/OrganizationContext';
 import { PageTitleProvider } from '@/context/PageTitleContext';
 import { UserProvider } from '@/context/UserContext';
@@ -21,7 +22,9 @@ createRoot(document.getElementById('root')!).render(
             <AuthGate>
               <UserProvider>
                 <OrganizationProvider>
-                  <App />
+                  <TooltipProvider>
+                    <App />
+                  </TooltipProvider>
                 </OrganizationProvider>
               </UserProvider>
             </AuthGate>


### PR DESCRIPTION
## Summary
- Wrap the authenticated app tree with `TooltipProvider` in `src/main.tsx` so Radix tooltip usage on organization runner views has a provider ancestor.
- Add regression coverage for non-cluster-admin organization runners rendering cluster-scoped runners with the disabled View action tooltip path.

Closes #102

## Test & Lint Summary
- `npm run typecheck` — passed
- `npm run lint` — passed with no errors
- `npm run test` — 80 passed / 0 failed / 0 skipped
- `npm run build` — passed

Manual hover check was not performed because this environment has no browser UI.