### PR TITLE
Fix agent roles section UI and gateway errors

### DIFF
--- a/src/__tests__/agent-roles-section.test.tsx
+++ b/src/__tests__/agent-roles-section.test.tsx
@@ -274,14 +274,28 @@ describe('AgentRolesSection', () => {
     });
   });
 
-  it('shows backend wiring guidance when gateway role methods are missing', async () => {
-    listAgentRoles.mockRejectedValueOnce(new ConnectError('not found', Code.NotFound));
+  it('shows backend wiring guidance when the gateway role route is missing', async () => {
+    listAgentRoles.mockRejectedValueOnce(new ConnectError('HTTP 404', Code.Unimplemented));
     renderSection();
 
     expect((await screen.findByTestId('agent-roles-load-error')).textContent).toContain(
       '/api/agynio.api.gateway.v1.AgentsGateway/*',
     );
     expect(screen.getByTestId('agent-roles-load-error').textContent).toContain('ListAgentRoles');
+  });
+
+  it('preserves legitimate service not-found errors', async () => {
+    listAgentRoles.mockRejectedValueOnce(new ConnectError('agent not found', Code.NotFound));
+    renderSection();
+
+    expect((await screen.findByTestId('agent-roles-load-error')).textContent).toBe('[not_found] agent not found');
+  });
+
+  it('does not treat Connect not-found codes as missing gateway routes', async () => {
+    listAgentRoles.mockRejectedValueOnce(new ConnectError('HTTP 404', Code.NotFound));
+    renderSection();
+
+    expect((await screen.findByTestId('agent-roles-load-error')).textContent).toBe('[not_found] HTTP 404');
   });
 
   it('shows a permission error when role management is denied', async () => {

--- a/src/__tests__/agent-roles-section.test.tsx
+++ b/src/__tests__/agent-roles-section.test.tsx
@@ -118,14 +118,18 @@ describe('AgentRolesSection', () => {
     batchGetUsers.mockReset();
 
     listAgentRoles.mockResolvedValue({
-      assignments: [buildAssignment('identity-owner', AgentRole.OWNER)],
+      assignments: [
+        buildAssignment('identity-owner', AgentRole.OWNER),
+        buildAssignment('identity-maintainer', AgentRole.MAINTAINER),
+      ],
     });
     mockMembersPages([
-      { memberships: [buildMembership('identity-owner'), buildMembership('identity-new')] },
+      { memberships: [buildMembership('identity-owner'), buildMembership('identity-maintainer'), buildMembership('identity-new')] },
     ]);
     batchGetUsers.mockResolvedValue({
       users: [
         buildUser('identity-owner', 'owner-user', 'Owner User', 'owner@example.com'),
+        buildUser('identity-maintainer', 'maintainer-user', 'Maintainer User', 'maintainer@example.com'),
         buildUser('identity-new', 'new-user', 'New User', 'new@example.com'),
       ],
     });
@@ -143,6 +147,7 @@ describe('AgentRolesSection', () => {
     expect(await screen.findByText('@owner-user')).toBeTruthy();
     expect(screen.getByText('identity-owner')).toBeTruthy();
     expect(screen.getByText('Owner')).toBeTruthy();
+    expect(screen.getByText('@maintainer-user')).toBeTruthy();
   });
 
   it('explains the availability interaction before the agent is private', async () => {
@@ -152,6 +157,22 @@ describe('AgentRolesSection', () => {
     expect(screen.getByText('Available when Private')).toBeTruthy();
     expect(screen.getByTestId('agent-roles-private-hint').textContent).toContain('set Availability to Private');
     expect(await screen.findByText('@owner-user')).toBeTruthy();
+  });
+
+  it('filters role assignments by shared user details', async () => {
+    renderSection();
+
+    expect(await screen.findByText('@owner-user')).toBeTruthy();
+    expect(screen.getByText('@maintainer-user')).toBeTruthy();
+
+    fireEvent.change(screen.getByTestId('agent-roles-search'), { target: { value: 'maintainer' } });
+
+    expect(screen.queryByText('@owner-user')).toBeNull();
+    expect(screen.getByText('@maintainer-user')).toBeTruthy();
+
+    fireEvent.change(screen.getByTestId('agent-roles-search'), { target: { value: 'participant' } });
+
+    expect((await screen.findByTestId('agent-roles-no-results')).textContent).toBe('No results found.');
   });
 
   it('adds a role assignment for an organization member', async () => {
@@ -227,7 +248,7 @@ describe('AgentRolesSection', () => {
   it('changes an existing role assignment', async () => {
     renderSection();
 
-    fireEvent.click(await screen.findByTestId('agent-roles-change'));
+    fireEvent.click((await screen.findAllByTestId('agent-roles-change'))[0]);
     expect(await screen.findByTestId('agent-roles-dialog')).toBeTruthy();
 
     const roleListbox = await openSelect('agent-roles-role');
@@ -246,11 +267,21 @@ describe('AgentRolesSection', () => {
   it('removes a role assignment', async () => {
     renderSection();
 
-    fireEvent.click(await screen.findByTestId('agent-roles-remove'));
+    fireEvent.click((await screen.findAllByTestId('agent-roles-remove'))[0]);
 
     await waitFor(() => {
       expect(removeAgentRole).toHaveBeenCalledWith({ agentId: 'agent-1', identityId: 'identity-owner' });
     });
+  });
+
+  it('shows backend wiring guidance when gateway role methods are missing', async () => {
+    listAgentRoles.mockRejectedValueOnce(new ConnectError('not found', Code.NotFound));
+    renderSection();
+
+    expect((await screen.findByTestId('agent-roles-load-error')).textContent).toContain(
+      '/api/agynio.api.gateway.v1.AgentsGateway/*',
+    );
+    expect(screen.getByTestId('agent-roles-load-error').textContent).toContain('ListAgentRoles');
   });
 
   it('shows a permission error when role management is denied', async () => {

--- a/src/pages/agent-detail/AgentRolesSection.tsx
+++ b/src/pages/agent-detail/AgentRolesSection.tsx
@@ -53,12 +53,16 @@ async function listActiveOrganizationMembers(organizationId: string): Promise<Me
   return memberships;
 }
 
+function isMissingGatewayRoleMethod(error: ConnectError) {
+  return error.code === Code.Unimplemented;
+}
+
 function formatRoleError(error: unknown, fallback: string) {
   if (error instanceof ConnectError) {
     if (error.code === Code.PermissionDenied) {
       return 'You do not have permission to manage agent sharing roles.';
     }
-    if (error.code === Code.NotFound || error.code === Code.Unimplemented) {
+    if (isMissingGatewayRoleMethod(error)) {
       return missingGatewayRoleMethodMessage;
     }
   }

--- a/src/pages/agent-detail/AgentRolesSection.tsx
+++ b/src/pages/agent-detail/AgentRolesSection.tsx
@@ -2,9 +2,9 @@ import { useMemo, useState } from 'react';
 import { Code, ConnectError } from '@connectrpc/connect';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { agentsClient, organizationsClient, usersClient } from '@/api/client';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Dialog,
   DialogClose,
@@ -14,9 +14,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AgentAvailability, AgentRole, type AgentRoleAssignment } from '@/gen/agynio/api/agents/v1/agents_pb';
+import { AgentsGateway } from '@/gen/agynio/api/gateway/v1/agents_pb';
 import { MembershipStatus, type Membership } from '@/gen/agynio/api/organizations/v1/organizations_pb';
 import { formatAgentRole } from '@/lib/format';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
@@ -29,6 +31,9 @@ type AgentRolesSectionProps = {
 };
 
 const assignableRoles = [AgentRole.OWNER, AgentRole.MAINTAINER, AgentRole.PARTICIPANT] as const;
+const agentsGatewayApiPath = `/api/${AgentsGateway.typeName}/*`;
+const missingGatewayRoleMethodMessage =
+  `Agent role management is not available from the gateway yet. The console is calling ${agentsGatewayApiPath}; update the gateway/backend to expose ListAgentRoles, SetAgentRole, and RemoveAgentRole.`;
 
 async function listActiveOrganizationMembers(organizationId: string): Promise<Membership[]> {
   const memberships: Membership[] = [];
@@ -49,8 +54,13 @@ async function listActiveOrganizationMembers(organizationId: string): Promise<Me
 }
 
 function formatRoleError(error: unknown, fallback: string) {
-  if (error instanceof ConnectError && error.code === Code.PermissionDenied) {
-    return 'You do not have permission to manage agent sharing roles.';
+  if (error instanceof ConnectError) {
+    if (error.code === Code.PermissionDenied) {
+      return 'You do not have permission to manage agent sharing roles.';
+    }
+    if (error.code === Code.NotFound || error.code === Code.Unimplemented) {
+      return missingGatewayRoleMethodMessage;
+    }
   }
   return error instanceof Error ? error.message : fallback;
 }
@@ -61,6 +71,7 @@ export function AgentRolesSection({ agentId, organizationId, availability }: Age
   const [selectedIdentityId, setSelectedIdentityId] = useState('');
   const [selectedRole, setSelectedRole] = useState<AgentRole>(AgentRole.PARTICIPANT);
   const [roleError, setRoleError] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
 
   const rolesQuery = useQuery({
     queryKey: ['agents', agentId, 'roles'],
@@ -116,6 +127,29 @@ export function AgentRolesSection({ agentId, organizationId, availability }: Age
     [assignments],
   );
 
+  const memberLabel = (identityId: string) => {
+    const user = userMap.get(identityId);
+    return user?.username ? `@${user.username}` : user?.name || user?.email || identityId;
+  };
+
+  const filteredAssignments = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+    if (!normalizedSearch) return assignments;
+
+    return assignments.filter((assignment) => {
+      const user = userMap.get(assignment.identityId);
+      const searchableValues = [
+        user?.username ? `@${user.username}` : user?.name || user?.email || assignment.identityId,
+        assignment.identityId,
+        user?.username ?? '',
+        user?.name ?? '',
+        user?.email ?? '',
+        formatAgentRole(assignment.role),
+      ];
+      return searchableValues.some((value) => value.toLowerCase().includes(normalizedSearch));
+    });
+  }, [assignments, searchTerm, userMap]);
+
   const setRoleMutation = useMutation({
     mutationFn: (payload: { identityId: string; role: AgentRole }) =>
       agentsClient.setAgentRole({ agentId, identityId: payload.identityId, role: payload.role }),
@@ -148,11 +182,6 @@ export function AgentRolesSection({ agentId, organizationId, availability }: Age
     },
   });
 
-  const memberLabel = (identityId: string) => {
-    const user = userMap.get(identityId);
-    return user?.username ? `@${user.username}` : user?.name || user?.email || identityId;
-  };
-
   const openEdit = (assignment?: AgentRoleAssignment) => {
     setSelectedIdentityId(assignment?.identityId ?? '');
     setSelectedRole(assignment?.role || AgentRole.PARTICIPANT);
@@ -164,29 +193,38 @@ export function AgentRolesSection({ agentId, organizationId, availability }: Age
     availability === AgentAvailability.PRIVATE
       ? 'Private agents are shared by assigning owner, maintainer, or participant roles to specific organization members.'
       : 'Assign roles now to prepare specific-user sharing before switching this agent to Private availability.';
+  const hasSearch = searchTerm.trim().length > 0;
 
   return (
-    <Card className="border-primary/40 bg-primary/5" data-testid="agent-roles-card">
-      <CardContent className="space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="space-y-2">
-            <div className="flex flex-wrap items-center gap-2">
-              <h3 className="text-lg font-semibold text-foreground">Share with specific users</h3>
-              <Badge variant={availability === AgentAvailability.PRIVATE ? 'default' : 'outline'} data-testid="agent-roles-availability">
-                {availability === AgentAvailability.PRIVATE ? 'Private sharing active' : 'Available when Private'}
-              </Badge>
-            </div>
-            <p className="max-w-2xl text-sm text-muted-foreground">{sharingDescription}</p>
-          </div>
+    <Card className="border-border" data-testid="agent-roles-card">
+      <CardHeader>
+        <CardTitle className="flex flex-wrap items-center gap-2 text-lg text-foreground">
+          Share with specific users
+          <Badge variant={availability === AgentAvailability.PRIVATE ? 'default' : 'outline'} data-testid="agent-roles-availability">
+            {availability === AgentAvailability.PRIVATE ? 'Private sharing active' : 'Available when Private'}
+          </Badge>
+        </CardTitle>
+        <CardDescription className="max-w-2xl">{sharingDescription}</CardDescription>
+        <CardAction>
           <Button variant="outline" size="sm" onClick={() => openEdit()} data-testid="agent-roles-add">
             Share agent
           </Button>
-        </div>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="space-y-4">
         {availability !== AgentAvailability.PRIVATE ? (
-          <div className="rounded-md border border-border bg-background p-3 text-sm text-muted-foreground" data-testid="agent-roles-private-hint">
+          <div className="rounded-md border border-border bg-muted/40 p-3 text-sm text-muted-foreground" data-testid="agent-roles-private-hint">
             To limit thread access to only the users listed here, set Availability to Private in Configuration.
           </div>
         ) : null}
+        <div className="max-w-sm">
+          <Input
+            placeholder="Search shared users..."
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            data-testid="agent-roles-search"
+          />
+        </div>
         {rolesQuery.isPending ? <div className="text-sm text-muted-foreground">Loading roles...</div> : null}
         {rolesQuery.isError ? (
           <div className="text-sm text-destructive" data-testid="agent-roles-load-error">
@@ -204,35 +242,41 @@ export function AgentRolesSection({ agentId, organizationId, availability }: Age
           </div>
         ) : null}
         {assignments.length === 0 && !rolesQuery.isPending ? (
-          <div className="text-sm text-muted-foreground" data-testid="agent-roles-empty">
+          <div className="rounded-md border border-border py-10 text-center text-sm text-muted-foreground" data-testid="agent-roles-empty">
             No users are explicitly shared on this agent yet.
           </div>
         ) : null}
         {assignments.length > 0 ? (
           <div className="divide-y divide-border rounded-md border border-border" data-testid="agent-roles-list">
-            {assignments.map((assignment) => (
-              <div key={assignment.identityId} className="flex flex-wrap items-center justify-between gap-3 p-3">
-                <div>
-                  <div className="text-sm font-medium text-foreground">{memberLabel(assignment.identityId)}</div>
-                  <div className="text-xs text-muted-foreground">{assignment.identityId}</div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Badge variant="secondary">{formatAgentRole(assignment.role)}</Badge>
-                  <Button variant="outline" size="sm" onClick={() => openEdit(assignment)} data-testid="agent-roles-change">
-                    Change
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => removeRoleMutation.mutate(assignment.identityId)}
-                    disabled={removeRoleMutation.isPending}
-                    data-testid="agent-roles-remove"
-                  >
-                    Remove
-                  </Button>
-                </div>
+            {filteredAssignments.length === 0 ? (
+              <div className="px-6 py-6 text-sm text-muted-foreground" data-testid="agent-roles-no-results">
+                {hasSearch ? 'No results found.' : 'No users are explicitly shared on this agent yet.'}
               </div>
-            ))}
+            ) : (
+              filteredAssignments.map((assignment) => (
+                <div key={assignment.identityId} className="flex flex-wrap items-center justify-between gap-3 p-3">
+                  <div>
+                    <div className="text-sm font-medium text-foreground">{memberLabel(assignment.identityId)}</div>
+                    <div className="text-xs text-muted-foreground">{assignment.identityId}</div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary">{formatAgentRole(assignment.role)}</Badge>
+                    <Button variant="outline" size="sm" onClick={() => openEdit(assignment)} data-testid="agent-roles-change">
+                      Change
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => removeRoleMutation.mutate(assignment.identityId)}
+                      disabled={removeRoleMutation.isPending}
+                      data-testid="agent-roles-remove"
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                </div>
+              ))
+            )}
           </div>
         ) : null}
       </CardContent>


### PR DESCRIPTION
## Summary
- Align Agent Roles with the standard card header/subheader/action layout used by agent detail blocks.
- Add search filtering for shared users by handle, identity ID, email/name, and role.
- Keep console role calls on `agynio.api.gateway.v1.AgentsGateway` and show actionable copy for missing gateway/backend role methods.

Closes #106

## Test & Lint Summary
- `npm run lint` — passed with no errors or warnings.
- `npm run typecheck` — passed.
- `npm test` — 82 passed / 0 failed / 0 skipped.
- `npm run build` — passed.