### PR TITLE
Fix Agent Roles section layout

### DIFF
--- a/src/__tests__/agent-roles-section.test.tsx
+++ b/src/__tests__/agent-roles-section.test.tsx
@@ -140,7 +140,7 @@ describe('AgentRolesSection', () => {
   it('makes specific-user private sharing discoverable', async () => {
     renderSection(AgentAvailability.PRIVATE);
 
-    expect(screen.getByText('Share with specific users')).toBeTruthy();
+    expect(screen.getByTestId('agent-roles-heading').textContent).toContain('Roles');
     expect(screen.getByText('Private sharing active')).toBeTruthy();
     expect(screen.getByText(/Private agents are shared by assigning owner, maintainer, or participant roles/i)).toBeTruthy();
 
@@ -153,10 +153,32 @@ describe('AgentRolesSection', () => {
   it('explains the availability interaction before the agent is private', async () => {
     renderSection(AgentAvailability.INTERNAL);
 
-    expect(screen.getByText('Share with specific users')).toBeTruthy();
+    expect(screen.getByTestId('agent-roles-heading').textContent).toContain('Roles');
     expect(screen.getByText('Available when Private')).toBeTruthy();
     expect(screen.getByTestId('agent-roles-private-hint').textContent).toContain('set Availability to Private');
     expect(await screen.findByText('@owner-user')).toBeTruthy();
+  });
+
+  it('keeps the heading outside the roles table card', async () => {
+    renderSection();
+
+    const heading = screen.getByTestId('agent-roles-heading');
+    expect(heading).toBeTruthy();
+    expect(screen.getByTestId('agent-roles-add')).toBeTruthy();
+    expect(await screen.findByTestId('agent-roles-table')).toBeTruthy();
+    expect(heading.closest('[data-testid="agent-roles-table"]')).toBeNull();
+    expect(heading.closest('[data-testid="agent-roles-empty"]')).toBeNull();
+  });
+
+  it('keeps the heading outside the roles empty-state card', async () => {
+    listAgentRoles.mockResolvedValueOnce({ assignments: [] });
+    renderSection();
+
+    const heading = screen.getByTestId('agent-roles-heading');
+    expect(heading).toBeTruthy();
+    expect(await screen.findByTestId('agent-roles-empty')).toBeTruthy();
+    expect(heading.closest('[data-testid="agent-roles-table"]')).toBeNull();
+    expect(heading.closest('[data-testid="agent-roles-empty"]')).toBeNull();
   });
 
   it('filters role assignments by shared user details', async () => {

--- a/src/pages/agent-detail/AgentRolesSection.tsx
+++ b/src/pages/agent-detail/AgentRolesSection.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { agentsClient, organizationsClient, usersClient } from '@/api/client';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import {
   Dialog,
   DialogClose,
@@ -200,90 +200,97 @@ export function AgentRolesSection({ agentId, organizationId, availability }: Age
   const hasSearch = searchTerm.trim().length > 0;
 
   return (
-    <Card className="border-border" data-testid="agent-roles-card">
-      <CardHeader>
-        <CardTitle className="flex flex-wrap items-center gap-2 text-lg text-foreground">
-          Share with specific users
-          <Badge variant={availability === AgentAvailability.PRIVATE ? 'default' : 'outline'} data-testid="agent-roles-availability">
-            {availability === AgentAvailability.PRIVATE ? 'Private sharing active' : 'Available when Private'}
-          </Badge>
-        </CardTitle>
-        <CardDescription className="max-w-2xl">{sharingDescription}</CardDescription>
-        <CardAction>
-          <Button variant="outline" size="sm" onClick={() => openEdit()} data-testid="agent-roles-add">
-            Share agent
-          </Button>
-        </CardAction>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {availability !== AgentAvailability.PRIVATE ? (
-          <div className="rounded-md border border-border bg-muted/40 p-3 text-sm text-muted-foreground" data-testid="agent-roles-private-hint">
-            To limit thread access to only the users listed here, set Availability to Private in Configuration.
-          </div>
-        ) : null}
-        <div className="max-w-sm">
-          <Input
-            placeholder="Search shared users..."
-            value={searchTerm}
-            onChange={(event) => setSearchTerm(event.target.value)}
-            data-testid="agent-roles-search"
-          />
+    <div className="space-y-4" data-testid="agent-roles-section">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3
+            className="flex flex-wrap items-center gap-2 text-lg font-semibold text-foreground"
+            data-testid="agent-roles-heading"
+          >
+            Roles
+            <Badge variant={availability === AgentAvailability.PRIVATE ? 'default' : 'outline'} data-testid="agent-roles-availability">
+              {availability === AgentAvailability.PRIVATE ? 'Private sharing active' : 'Available when Private'}
+            </Badge>
+          </h3>
+          <p className="max-w-2xl text-sm text-muted-foreground">{sharingDescription}</p>
         </div>
-        {rolesQuery.isPending ? <div className="text-sm text-muted-foreground">Loading roles...</div> : null}
-        {rolesQuery.isError ? (
-          <div className="text-sm text-destructive" data-testid="agent-roles-load-error">
-            {formatRoleError(rolesQuery.error, 'Failed to load sharing roles.')}
-          </div>
-        ) : null}
-        {membersQuery.isError ? (
-          <div className="text-sm text-destructive" data-testid="agent-roles-members-error">
-            Failed to load organization members for sharing.
-          </div>
-        ) : null}
-        {roleError ? (
-          <div className="text-sm text-destructive" data-testid="agent-roles-error">
-            {roleError}
-          </div>
-        ) : null}
-        {assignments.length === 0 && !rolesQuery.isPending ? (
-          <div className="rounded-md border border-border py-10 text-center text-sm text-muted-foreground" data-testid="agent-roles-empty">
+        <Button variant="outline" size="sm" onClick={() => openEdit()} data-testid="agent-roles-add">
+          Share agent
+        </Button>
+      </div>
+      {availability !== AgentAvailability.PRIVATE ? (
+        <div className="rounded-md border border-border bg-muted/40 p-3 text-sm text-muted-foreground" data-testid="agent-roles-private-hint">
+          To limit thread access to only the users listed here, set Availability to Private in Configuration.
+        </div>
+      ) : null}
+      <div className="max-w-sm">
+        <Input
+          placeholder="Search shared users..."
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+          data-testid="agent-roles-search"
+        />
+      </div>
+      {rolesQuery.isPending ? <div className="text-sm text-muted-foreground">Loading roles...</div> : null}
+      {rolesQuery.isError ? (
+        <div className="text-sm text-destructive" data-testid="agent-roles-load-error">
+          {formatRoleError(rolesQuery.error, 'Failed to load sharing roles.')}
+        </div>
+      ) : null}
+      {membersQuery.isError ? (
+        <div className="text-sm text-destructive" data-testid="agent-roles-members-error">
+          Failed to load organization members for sharing.
+        </div>
+      ) : null}
+      {roleError ? (
+        <div className="text-sm text-destructive" data-testid="agent-roles-error">
+          {roleError}
+        </div>
+      ) : null}
+      {assignments.length === 0 && !rolesQuery.isPending ? (
+        <Card className="border-border" data-testid="agent-roles-empty">
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
             No users are explicitly shared on this agent yet.
-          </div>
-        ) : null}
-        {assignments.length > 0 ? (
-          <div className="divide-y divide-border rounded-md border border-border" data-testid="agent-roles-list">
-            {filteredAssignments.length === 0 ? (
-              <div className="px-6 py-6 text-sm text-muted-foreground" data-testid="agent-roles-no-results">
-                {hasSearch ? 'No results found.' : 'No users are explicitly shared on this agent yet.'}
-              </div>
-            ) : (
-              filteredAssignments.map((assignment) => (
-                <div key={assignment.identityId} className="flex flex-wrap items-center justify-between gap-3 p-3">
-                  <div>
-                    <div className="text-sm font-medium text-foreground">{memberLabel(assignment.identityId)}</div>
-                    <div className="text-xs text-muted-foreground">{assignment.identityId}</div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Badge variant="secondary">{formatAgentRole(assignment.role)}</Badge>
-                    <Button variant="outline" size="sm" onClick={() => openEdit(assignment)} data-testid="agent-roles-change">
-                      Change
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => removeRoleMutation.mutate(assignment.identityId)}
-                      disabled={removeRoleMutation.isPending}
-                      data-testid="agent-roles-remove"
-                    >
-                      Remove
-                    </Button>
-                  </div>
+          </CardContent>
+        </Card>
+      ) : null}
+      {assignments.length > 0 ? (
+        <Card className="border-border" data-testid="agent-roles-table">
+          <CardContent className="px-0">
+            <div className="divide-y divide-border" data-testid="agent-roles-list">
+              {filteredAssignments.length === 0 ? (
+                <div className="px-6 py-6 text-sm text-muted-foreground" data-testid="agent-roles-no-results">
+                  {hasSearch ? 'No results found.' : 'No users are explicitly shared on this agent yet.'}
                 </div>
-              ))
-            )}
-          </div>
-        ) : null}
-      </CardContent>
+              ) : (
+                filteredAssignments.map((assignment) => (
+                  <div key={assignment.identityId} className="flex flex-wrap items-center justify-between gap-3 p-3">
+                    <div>
+                      <div className="text-sm font-medium text-foreground">{memberLabel(assignment.identityId)}</div>
+                      <div className="text-xs text-muted-foreground">{assignment.identityId}</div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary">{formatAgentRole(assignment.role)}</Badge>
+                      <Button variant="outline" size="sm" onClick={() => openEdit(assignment)} data-testid="agent-roles-change">
+                        Change
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => removeRoleMutation.mutate(assignment.identityId)}
+                        disabled={removeRoleMutation.isPending}
+                        data-testid="agent-roles-remove"
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent data-testid="agent-roles-dialog">
           <DialogHeader>
@@ -343,6 +350,6 @@ export function AgentRolesSection({ agentId, organizationId, availability }: Age
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </Card>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Move the Agent Roles header, description, badge, and Share agent action outside the content card to match other Agent detail sections.
- Keep availability hints, search, and error guidance outside the table/empty-state card.
- Preserve existing role list/add/change/remove behavior and gateway/backend 404 guidance.
- Add tests that assert the Roles heading is present and outside the table/empty-state cards.

Closes #109

## Test & Lint Summary
- `npm run lint` — passed with no errors.
- `npm run typecheck` — passed with no errors.
- `npm test` — 20 passed, 0 failed, 0 skipped; 86 tests passed, 0 failed, 0 skipped.
- `npm run build` — passed.