### PR TITLE
feat(auth): request configured OIDC resource

### DIFF
--- a/charts/console-app/Chart.yaml
+++ b/charts/console-app/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: console-app
 description: Helm chart for deploying the agyn Console App.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.10.11
+appVersion: 0.10.11
 home: https://github.com/agynio/console-app
 sources:
   - https://github.com/agynio/console-app

--- a/charts/console-app/values.yaml
+++ b/charts/console-app/values.yaml
@@ -79,6 +79,8 @@ env:
     value: "{{ .Values.oidcClientId }}"
   - name: OIDC_SCOPE
     value: "{{ .Values.oidcScope }}"
+  - name: OIDC_RESOURCE
+    value: "{{ .Values.oidcResource }}"
   - name: API_BASE_URL
     value: "{{ .Values.apiBaseUrl }}"
 envFrom: []
@@ -196,6 +198,7 @@ metrics:
 oidcAuthority: ""
 oidcClientId: ""
 oidcScope: "openid profile email offline_access"
+oidcResource: ""
 apiBaseUrl: /api
 
 nginx:

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -26,6 +26,21 @@ describe('runtime config', () => {
       authority: 'https://auth.example.com',
       clientId: 'console-client',
       scope: 'openid profile',
+      resource: null,
+    });
+  });
+
+  it('reads the OIDC resource when provided', async () => {
+    window.__ENV__ = {
+      OIDC_AUTHORITY: 'https://auth.example.com',
+      OIDC_CLIENT_ID: 'console-client',
+      OIDC_SCOPE: 'openid profile',
+      OIDC_RESOURCE: 'https://api.example.com',
+    };
+    const { oidcConfig } = await import('@/config');
+    expect(oidcConfig).toMatchObject({
+      enabled: true,
+      resource: 'https://api.example.com',
     });
   });
 

--- a/src/auth/user-manager.ts
+++ b/src/auth/user-manager.ts
@@ -8,6 +8,7 @@ export const userManager = oidcConfig.enabled
       redirect_uri: `${window.location.origin}/callback`,
       post_logout_redirect_uri: window.location.origin,
       scope: oidcConfig.scope,
+      resource: oidcConfig.resource ?? undefined,
       response_type: 'code',
       userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       automaticSilentRenew: true,

--- a/src/auth/user-manager.ts
+++ b/src/auth/user-manager.ts
@@ -12,14 +12,6 @@ export const userManager = oidcConfig.enabled
       response_type: 'code',
       userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       automaticSilentRenew: true,
-      metadata: {
-        issuer: oidcConfig.authority,
-        authorization_endpoint: `${oidcConfig.authority}/authorize`,
-        token_endpoint: `${oidcConfig.authority}/token`,
-        userinfo_endpoint: `${oidcConfig.authority}/userinfo`,
-        end_session_endpoint: `${oidcConfig.authority}/end-session`,
-        jwks_uri: `${oidcConfig.authority}/jwks.json`,
-      },
     })
   : null;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ type RuntimeEnv = {
   OIDC_AUTHORITY?: string;
   OIDC_CLIENT_ID?: string;
   OIDC_SCOPE?: string;
+  OIDC_RESOURCE?: string;
 };
 
 type OidcConfigEnabled = {
@@ -10,6 +11,7 @@ type OidcConfigEnabled = {
   authority: string;
   clientId: string;
   scope: string;
+  resource: string | null;
 };
 
 type OidcConfigDisabled = {
@@ -45,6 +47,7 @@ const apiBaseUrl = stripTrailingSlash(rawApiBase ?? '/api');
 const authority = readConfigValue('OIDC_AUTHORITY', 'VITE_OIDC_AUTHORITY');
 const clientId = readConfigValue('OIDC_CLIENT_ID', 'VITE_OIDC_CLIENT_ID');
 const scope = readConfigValue('OIDC_SCOPE', 'VITE_OIDC_SCOPE');
+const resource = readConfigValue('OIDC_RESOURCE', 'VITE_OIDC_RESOURCE');
 const oidcConfigured = Boolean(authority || clientId || scope);
 
 export const oidcConfig: OidcConfig = oidcConfigured
@@ -53,6 +56,7 @@ export const oidcConfig: OidcConfig = oidcConfigured
       authority: requireConfig('OIDC_AUTHORITY', authority),
       clientId: requireConfig('OIDC_CLIENT_ID', clientId),
       scope: requireConfig('OIDC_SCOPE', scope),
+      resource,
     }
   : { enabled: false };
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@ interface ImportMetaEnv {
   readonly VITE_OIDC_AUTHORITY?: string;
   readonly VITE_OIDC_CLIENT_ID?: string;
   readonly VITE_OIDC_SCOPE?: string;
+  readonly VITE_OIDC_RESOURCE?: string;
 }
 
 interface ImportMeta {
@@ -15,5 +16,6 @@ interface Window {
     OIDC_AUTHORITY?: string;
     OIDC_CLIENT_ID?: string;
     OIDC_SCOPE?: string;
+    OIDC_RESOURCE?: string;
   };
 }


### PR DESCRIPTION
## Summary

Supports agynio/infrastructure#22 and agynio/infrastructure#23 by making the Logto API resource indicator functional instead of an inert chart value.

This PR wires the OIDC resource/audience through this repository's runtime/chart contract so the platform chart can pass `https://agyn.cloud` from the Logto workspace outputs.

## Validation

See the parent infrastructure PR for the full cross-repository validation summary.
