### PR TITLE
feat(activity): show thread workloads and storage

### DIFF
--- a/src/__tests__/volume-attachments.test.ts
+++ b/src/__tests__/volume-attachments.test.ts
@@ -1,0 +1,32 @@
+import { create } from '@bufbuild/protobuf';
+import { describe, expect, it } from 'vitest';
+import { AttachmentKind, AttachmentSchema } from '@/gen/agynio/api/runners/v1/runners_pb';
+import { formatVolumeAttachmentLabel, summarizeVolumeAttachments } from '@/lib/volume';
+
+describe('volume attachment labels', () => {
+  it('formats attachments by kind and name', () => {
+    expect(
+      formatVolumeAttachmentLabel(
+        create(AttachmentSchema, {
+          kind: AttachmentKind.AGENT,
+          id: 'agent-1',
+          name: 'Research agent',
+        }),
+      ),
+    ).toBe('Agent Research agent');
+  });
+
+  it('summarizes multiple attachments with a remaining count', () => {
+    const summary = summarizeVolumeAttachments([
+      create(AttachmentSchema, { kind: AttachmentKind.HOOK, id: 'hook-1', name: 'Hook B' }),
+      create(AttachmentSchema, { kind: AttachmentKind.MCP, id: 'mcp-1', name: 'MCP A' }),
+      create(AttachmentSchema, { kind: AttachmentKind.AGENT, id: 'agent-1', name: 'Agent C' }),
+    ]);
+
+    expect(summary).toBe('Agent Agent C +2 more');
+  });
+
+  it('uses unattached for empty attachments', () => {
+    expect(summarizeVolumeAttachments([])).toBe('Unattached');
+  });
+});

--- a/src/components/WorkloadsTable.tsx
+++ b/src/components/WorkloadsTable.tsx
@@ -45,6 +45,7 @@ type WorkloadsTableProps = {
   rowLinkMode?: 'row' | 'action';
   actionLabel?: string;
   controls?: WorkloadsTableControls;
+  preserveApiOrder?: boolean;
   filterBar?: ReactNode;
   searchPlaceholder?: string;
   hasActiveFilters?: boolean;
@@ -67,6 +68,7 @@ export function WorkloadsTable({
   rowLinkMode = 'action',
   actionLabel,
   controls,
+  preserveApiOrder = false,
   filterBar,
   searchPlaceholder = 'Search workloads...',
   hasActiveFilters,
@@ -128,8 +130,9 @@ export function WorkloadsTable({
   const sortKey = controls?.sortKey ?? (listControls.sortKey as WorkloadSortKey);
   const sortDirection = controls?.sortDirection ?? listControls.sortDirection;
   const handleSort = controls?.onSort ?? listControls.handleSort;
+  const shouldPreserveApiOrder = preserveApiOrder && !controls;
 
-  const visibleWorkloads = controls ? workloads : listControls.filteredItems;
+  const visibleWorkloads = controls || shouldPreserveApiOrder ? workloads : listControls.filteredItems;
   const hasSearch = showSearch && searchTerm.trim().length > 0;
   const hasFilters = controls ? (hasActiveFilters ?? hasSearch) : hasSearch;
   const actionLabelText = actionLabel?.trim() || 'View';
@@ -184,23 +187,31 @@ export function WorkloadsTable({
             style={gridStyle}
             data-testid={`${testIdPrefix}-header`}
           >
-            <SortableHeader
-              label={agentLabel}
-              sortKey="agentId"
-              activeSortKey={sortKey}
-              sortDirection={sortDirection}
-              onSort={handleSort}
-            />
-            {showRunnerColumn ? (
+            {shouldPreserveApiOrder ? (
+              <span>{agentLabel}</span>
+            ) : (
               <SortableHeader
-                label={runnerLabel}
-                sortKey="runnerId"
+                label={agentLabel}
+                sortKey="agentId"
                 activeSortKey={sortKey}
                 sortDirection={sortDirection}
                 onSort={handleSort}
               />
+            )}
+            {showRunnerColumn ? (
+              shouldPreserveApiOrder ? (
+                <span>{runnerLabel}</span>
+              ) : (
+                <SortableHeader
+                  label={runnerLabel}
+                  sortKey="runnerId"
+                  activeSortKey={sortKey}
+                  sortDirection={sortDirection}
+                  onSort={handleSort}
+                />
+              )
             ) : null}
-            {controls ? (
+            {controls || shouldPreserveApiOrder ? (
               <span>Thread ID</span>
             ) : (
               <SortableHeader
@@ -211,29 +222,41 @@ export function WorkloadsTable({
                 onSort={handleSort}
               />
             )}
-            <SortableHeader
-              label="Status"
-              sortKey="status"
-              activeSortKey={sortKey}
-              sortDirection={sortDirection}
-              onSort={handleSort}
-            />
-            <span>Containers</span>
-            <SortableHeader
-              label="Started"
-              sortKey="started"
-              activeSortKey={sortKey}
-              sortDirection={sortDirection}
-              onSort={handleSort}
-            />
-            {showDuration ? (
+            {shouldPreserveApiOrder ? (
+              <span>Status</span>
+            ) : (
               <SortableHeader
-                label="Duration"
-                sortKey="duration"
+                label="Status"
+                sortKey="status"
                 activeSortKey={sortKey}
                 sortDirection={sortDirection}
                 onSort={handleSort}
               />
+            )}
+            <span>Containers</span>
+            {shouldPreserveApiOrder ? (
+              <span>Started</span>
+            ) : (
+              <SortableHeader
+                label="Started"
+                sortKey="started"
+                activeSortKey={sortKey}
+                sortDirection={sortDirection}
+                onSort={handleSort}
+              />
+            )}
+            {showDuration ? (
+              shouldPreserveApiOrder ? (
+                <span>Duration</span>
+              ) : (
+                <SortableHeader
+                  label="Duration"
+                  sortKey="duration"
+                  activeSortKey={sortKey}
+                  sortDirection={sortDirection}
+                  onSort={handleSort}
+                />
+              )
             ) : null}
             {hasAction ? <span className="text-right">Action</span> : null}
           </div>

--- a/src/components/WorkloadsTable.tsx
+++ b/src/components/WorkloadsTable.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import type { ListWorkloadsResponse, Workload } from '@/gen/agynio/api/runners/v1/runners_pb';
+import type { Workload } from '@/gen/agynio/api/runners/v1/runners_pb';
 import { WorkloadStatus } from '@/gen/agynio/api/runners/v1/runners_pb';
 import { type SortDirection, useListControls } from '@/hooks/useListControls';
 import {
@@ -31,7 +31,7 @@ type WorkloadsTableControls = {
 
 type WorkloadsTableProps = {
   workloads: Workload[];
-  query: UseInfiniteQueryResult<InfiniteData<ListWorkloadsResponse, unknown>, Error>;
+  query: UseInfiniteQueryResult<InfiniteData<{ nextPageToken: string }, unknown>, Error>;
   showRunnerColumn?: boolean;
   showDuration?: boolean;
   showSearch?: boolean;

--- a/src/lib/volume.ts
+++ b/src/lib/volume.ts
@@ -1,0 +1,31 @@
+import { AttachmentKind, type Attachment } from '@/gen/agynio/api/runners/v1/runners_pb';
+import { EMPTY_PLACEHOLDER } from '@/lib/format';
+
+const UNATTACHED_LABEL = 'Unattached';
+
+const ATTACHMENT_KIND_LABELS: Record<AttachmentKind, string> = {
+  [AttachmentKind.UNSPECIFIED]: 'Attachment',
+  [AttachmentKind.AGENT]: 'Agent',
+  [AttachmentKind.MCP]: 'MCP',
+  [AttachmentKind.HOOK]: 'Hook',
+};
+
+export const formatVolumeAttachmentLabel = (attachment: Attachment) => {
+  const name = attachment.name?.trim() || attachment.id || '';
+  if (!name) return EMPTY_PLACEHOLDER;
+  const kindLabel = ATTACHMENT_KIND_LABELS[attachment.kind] ?? 'Attachment';
+  return kindLabel === 'Attachment' ? name : `${kindLabel} ${name}`;
+};
+
+const resolveAttachmentSortKey = (attachment: Attachment) => attachment.name?.trim() || attachment.id || '';
+
+export const summarizeVolumeAttachments = (attachments: Attachment[]) => {
+  if (attachments.length === 0) return UNATTACHED_LABEL;
+  const labels = [...attachments]
+    .sort((left, right) => resolveAttachmentSortKey(left).localeCompare(resolveAttachmentSortKey(right)))
+    .map((attachment) => formatVolumeAttachmentLabel(attachment))
+    .filter((label) => label !== EMPTY_PLACEHOLDER);
+  if (labels.length === 0) return UNATTACHED_LABEL;
+  if (labels.length === 1) return labels[0];
+  return `${labels[0]} +${labels.length - 1} more`;
+};

--- a/src/pages/OrganizationActivityStorageTab.tsx
+++ b/src/pages/OrganizationActivityStorageTab.tsx
@@ -9,12 +9,10 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import {
-  AttachmentKind,
   ListVolumesSortField,
   SortDirection as VolumesSortDirection,
   VolumeAttachmentFilterKind,
   VolumeStatus,
-  type Attachment,
   type Volume,
 } from '@/gen/agynio/api/runners/v1/runners_pb';
 import type { NotificationEnvelope } from '@/gen/agynio/api/notifications/v1/notifications_pb';
@@ -23,8 +21,7 @@ import { useNotifications } from '@/hooks/useNotifications';
 import { type SortDirection } from '@/hooks/useListControls';
 import { EMPTY_PLACEHOLDER, formatDateOnly, formatVolumeStatus, truncate } from '@/lib/format';
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '@/lib/pagination';
-
-const UNATTACHED_LABEL = 'Unattached';
+import { summarizeVolumeAttachments } from '@/lib/volume';
 
 type VolumeSortKey = 'name' | 'size' | 'status' | 'created';
 
@@ -43,34 +40,7 @@ const VOLUME_ATTACHMENT_OPTIONS = [
   { value: String(VolumeAttachmentFilterKind.UNATTACHED), label: 'Unattached' },
 ];
 
-const ATTACHMENT_KIND_LABELS: Record<AttachmentKind, string> = {
-  [AttachmentKind.UNSPECIFIED]: 'Attachment',
-  [AttachmentKind.AGENT]: 'Agent',
-  [AttachmentKind.MCP]: 'MCP',
-  [AttachmentKind.HOOK]: 'Hook',
-};
-
 const getVolumeName = (volume: Volume) => volume.volumeName?.trim() || '';
-
-const formatAttachmentLabel = (attachment: Attachment) => {
-  const name = attachment.name?.trim() || attachment.id || '';
-  if (!name) return EMPTY_PLACEHOLDER;
-  const kindLabel = ATTACHMENT_KIND_LABELS[attachment.kind] ?? 'Attachment';
-  return kindLabel === 'Attachment' ? name : `${kindLabel} ${name}`;
-};
-
-const resolveAttachmentSortKey = (attachment: Attachment) => attachment.name?.trim() || attachment.id || '';
-
-const summarizeAttachments = (attachments: Attachment[]) => {
-  if (attachments.length === 0) return UNATTACHED_LABEL;
-  const labels = [...attachments]
-    .sort((left, right) => resolveAttachmentSortKey(left).localeCompare(resolveAttachmentSortKey(right)))
-    .map((attachment) => formatAttachmentLabel(attachment))
-    .filter((label) => label !== EMPTY_PLACEHOLDER);
-  if (labels.length === 0) return UNATTACHED_LABEL;
-  if (labels.length === 1) return labels[0];
-  return `${labels[0]} +${labels.length - 1} more`;
-};
 
 const extractVolumeId = (payload?: NotificationEnvelope['payload']): string | null => {
   if (!payload) return null;
@@ -399,7 +369,7 @@ export function OrganizationActivityStorageTab() {
                 const volumeId = volume.volumeId || volume.meta?.id || '';
                 const volumeLink = volumeId ? `/organizations/${organizationId}/volumes/${volumeId}` : null;
                 const sizeLabel = volume.sizeGb ? `${volume.sizeGb} GB` : EMPTY_PLACEHOLDER;
-                const attachedLabel = summarizeAttachments(volume.attachments ?? []);
+                const attachedLabel = summarizeVolumeAttachments(volume.attachments ?? []);
                 const createdLabel = formatDateOnly(volume.meta?.createdAt);
                 return (
                   <div

--- a/src/pages/OrganizationThreadDetailPage.tsx
+++ b/src/pages/OrganizationThreadDetailPage.tsx
@@ -3,14 +3,16 @@ import { NavLink, useParams } from 'react-router-dom';
 import { create } from '@bufbuild/protobuf';
 import { DurationSchema } from '@bufbuild/protobuf/wkt';
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
-import { filesClient, threadsClient } from '@/api/client';
+import { filesClient, runnersClient, threadsClient } from '@/api/client';
 import { LoadMoreButton } from '@/components/LoadMoreButton';
+import { WorkloadsTable } from '@/components/WorkloadsTable';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { MessageOrder } from '@/gen/agynio/api/threads/v1/threads_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useIdentityHandles } from '@/hooks/useIdentityHandles';
+import { useNotifications } from '@/hooks/useNotifications';
 import {
   EMPTY_PLACEHOLDER,
   formatDateOnly,
@@ -114,12 +116,31 @@ export function OrganizationThreadDetailPage() {
     refetchOnWindowFocus: false,
   });
 
+  const workloadsQuery = useInfiniteQuery({
+    queryKey: ['threads', resolvedThreadId, 'workloads'],
+    queryFn: ({ pageParam }) =>
+      runnersClient.listWorkloadsByThread({
+        threadId: resolvedThreadId,
+        pageSize: DEFAULT_PAGE_SIZE,
+        pageToken: pageParam,
+      }),
+    initialPageParam: '',
+    getNextPageParam: (lastPage) => lastPage.nextPageToken || undefined,
+    enabled: Boolean(resolvedThreadId),
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+
   const thread = threadQuery.data?.thread;
   const messages = useMemo(
     () => messagesQuery.data?.pages.flatMap((page) => page.messages) ?? [],
     [messagesQuery.data?.pages],
   );
   const participants = useMemo(() => thread?.participants ?? [], [thread?.participants]);
+  const workloads = useMemo(
+    () => workloadsQuery.data?.pages.flatMap((page) => page.workloads) ?? [],
+    [workloadsQuery.data?.pages],
+  );
 
   const identityIds = useMemo(() => {
     const ids = new Set<string>();
@@ -139,6 +160,20 @@ export function OrganizationThreadDetailPage() {
   const messageCount = thread?.messageCount ?? 0;
   const isThreadLoading = threadQuery.isPending;
   const isThreadError = threadQuery.isError;
+
+  const notificationRooms = useMemo(() => {
+    const rooms: string[] = [];
+    if (organizationId) rooms.push(`organization:${organizationId}`);
+    if (resolvedThreadId) rooms.push(`thread:${resolvedThreadId}`);
+    return rooms;
+  }, [organizationId, resolvedThreadId]);
+
+  useNotifications({
+    events: ['workload.status_changed', 'workload.updated'],
+    invalidateKeys: [['threads', resolvedThreadId, 'workloads']],
+    rooms: notificationRooms,
+    enabled: Boolean(resolvedThreadId) && notificationRooms.length > 0,
+  });
 
   return (
     <div className="space-y-6">
@@ -226,6 +261,34 @@ export function OrganizationThreadDetailPage() {
               </div>
             )
           ) : null}
+        </CardContent>
+      </Card>
+      <Card className="border-border" data-testid="thread-workloads-card">
+        <CardHeader className="pb-0">
+          <CardTitle>Associated workloads</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">Workloads created for this thread.</p>
+          <WorkloadsTable
+            workloads={workloads}
+            query={workloadsQuery}
+            showRunnerColumn
+            showDuration
+            showSearch={false}
+            rowLinkMode="row"
+            getWorkloadLink={(workload) => {
+              const linkedWorkloadId = workload.meta?.id;
+              if (!linkedWorkloadId) return null;
+              return `/organizations/${organizationId}/workloads/${linkedWorkloadId}`;
+            }}
+            getAgentLink={(workload) =>
+              workload.agentId ? `/organizations/${organizationId}/agents/${workload.agentId}` : null
+            }
+            getRunnerLink={(workload) =>
+              workload.runnerId ? `/organizations/${organizationId}/runners/${workload.runnerId}` : null
+            }
+            testIdPrefix="thread-workloads"
+          />
         </CardContent>
       </Card>
       <Card className="border-border" data-testid="thread-messages-card">

--- a/src/pages/OrganizationThreadDetailPage.tsx
+++ b/src/pages/OrganizationThreadDetailPage.tsx
@@ -275,6 +275,7 @@ export function OrganizationThreadDetailPage() {
             showRunnerColumn
             showDuration
             showSearch={false}
+            preserveApiOrder
             rowLinkMode="row"
             getWorkloadLink={(workload) => {
               const linkedWorkloadId = workload.meta?.id;

--- a/src/pages/VolumeDetailPage.tsx
+++ b/src/pages/VolumeDetailPage.tsx
@@ -6,24 +6,11 @@ import { runnersClient } from '@/api/client';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { AttachmentKind, type Attachment, VolumeStatus } from '@/gen/agynio/api/runners/v1/runners_pb';
+import { VolumeStatus } from '@/gen/agynio/api/runners/v1/runners_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useNotifications } from '@/hooks/useNotifications';
 import { EMPTY_PLACEHOLDER, formatTimestamp, formatVolumeStatus, truncate } from '@/lib/format';
-
-const ATTACHMENT_KIND_LABELS: Record<AttachmentKind, string> = {
-  [AttachmentKind.UNSPECIFIED]: 'Attachment',
-  [AttachmentKind.AGENT]: 'Agent',
-  [AttachmentKind.MCP]: 'MCP',
-  [AttachmentKind.HOOK]: 'Hook',
-};
-
-const formatAttachmentLabel = (attachment: Attachment) => {
-  const name = attachment.name?.trim() || attachment.id || '';
-  if (!name) return EMPTY_PLACEHOLDER;
-  const kindLabel = ATTACHMENT_KIND_LABELS[attachment.kind] ?? 'Attachment';
-  return kindLabel === 'Attachment' ? name : `${kindLabel} ${name}`;
-};
+import { formatVolumeAttachmentLabel } from '@/lib/volume';
 
 const getStatusVariant = (status: VolumeStatus) => {
   if (status === VolumeStatus.ACTIVE) return 'default';
@@ -196,7 +183,7 @@ export function VolumeDetailPage() {
               ) : (
                 <div className="space-y-3">
                   {attachments.map((attachment) => {
-                    const label = formatAttachmentLabel(attachment);
+                    const label = formatVolumeAttachmentLabel(attachment);
                     return (
                       <div key={`${attachment.kind}-${attachment.id}`} className="text-sm text-foreground">
                         <div className="font-medium">{label}</div>

--- a/src/pages/WorkloadDetailPage.tsx
+++ b/src/pages/WorkloadDetailPage.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import { NavLink, useLocation, useParams } from 'react-router-dom';
 import { Code, ConnectError } from '@connectrpc/connect';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, type InfiniteData, type UseInfiniteQueryResult } from '@tanstack/react-query';
 import { runnersClient } from '@/api/client';
+import { LoadMoreButton } from '@/components/LoadMoreButton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import type { Container } from '@/gen/agynio/api/runners/v1/runners_pb';
-import { ContainerRole, ContainerStatus, WorkloadStatus } from '@/gen/agynio/api/runners/v1/runners_pb';
+import type { Container, Volume } from '@/gen/agynio/api/runners/v1/runners_pb';
+import { ContainerRole, ContainerStatus, VolumeStatus, WorkloadStatus } from '@/gen/agynio/api/runners/v1/runners_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useNotifications } from '@/hooks/useNotifications';
 import {
@@ -16,9 +17,12 @@ import {
   formatContainerStatus,
   formatDurationBetween,
   formatTimestamp,
+  formatVolumeStatus,
   formatWorkloadStatus,
   truncate,
 } from '@/lib/format';
+import { DEFAULT_PAGE_SIZE } from '@/lib/pagination';
+import { summarizeVolumeAttachments } from '@/lib/volume';
 
 type LogStreamState = 'loading' | 'streaming' | 'ended' | 'unavailable' | 'error';
 
@@ -51,6 +55,13 @@ const resolveContainerVariant = (status: ContainerStatus) => {
   if (status === ContainerStatus.RUNNING) return 'default';
   if (status === ContainerStatus.WAITING) return 'secondary';
   if (status === ContainerStatus.TERMINATED) return 'outline';
+  return 'outline';
+};
+
+const resolveVolumeVariant = (status: VolumeStatus) => {
+  if (status === VolumeStatus.ACTIVE) return 'default';
+  if (status === VolumeStatus.PROVISIONING) return 'secondary';
+  if (status === VolumeStatus.FAILED) return 'destructive';
   return 'outline';
 };
 
@@ -249,6 +260,78 @@ function ContainerPanel({ container, index }: ContainerPanelProps) {
   );
 }
 
+type ThreadStoragePanelProps = {
+  currentPath: string;
+  organizationId: string;
+  volumes: Volume[];
+  volumesQuery: UseInfiniteQueryResult<
+    InfiniteData<Awaited<ReturnType<typeof runnersClient.listVolumesByThread>>, unknown>,
+    Error
+  >;
+};
+
+function ThreadStoragePanel({ currentPath, organizationId, volumes, volumesQuery }: ThreadStoragePanelProps) {
+  return (
+    <Card className="border-border" data-testid="workload-thread-storage-card">
+      <CardContent className="space-y-4">
+        <div>
+          <h3 className="text-lg font-semibold text-foreground">Attached storage</h3>
+          <p className="text-sm text-muted-foreground">Persistent storage associated with this workload's thread.</p>
+        </div>
+        {volumesQuery.isPending ? <div className="text-sm text-muted-foreground">Loading storage volumes...</div> : null}
+        {volumesQuery.isError ? <div className="text-sm text-muted-foreground">Failed to load storage.</div> : null}
+        {volumes.length === 0 && !volumesQuery.isPending && !volumesQuery.isError ? (
+          <div className="text-sm text-muted-foreground">No storage volumes found for this thread.</div>
+        ) : null}
+        {volumes.length > 0 ? (
+          <div className="divide-y divide-border rounded-md border border-border" data-testid="workload-thread-storage-list">
+            {volumes.map((volume) => {
+              const volumeId = volume.volumeId || volume.meta?.id || '';
+              const volumeName = volume.volumeName?.trim() || EMPTY_PLACEHOLDER;
+              const volumeLink = volumeId ? `/organizations/${organizationId}/volumes/${volumeId}` : null;
+              const sizeLabel = volume.sizeGb ? `${volume.sizeGb} GB` : EMPTY_PLACEHOLDER;
+              const attachedLabel = summarizeVolumeAttachments(volume.attachments ?? []);
+              return (
+                <div
+                  key={volume.meta?.id ?? volume.volumeId}
+                  className="grid items-center gap-2 px-4 py-3 text-sm text-foreground md:grid-cols-[2fr_1fr_2fr_140px]"
+                  data-testid="workload-thread-storage-row"
+                >
+                  <div className="font-medium" data-testid="workload-thread-storage-name">
+                    {volumeLink ? (
+                      <NavLink to={volumeLink} state={{ from: currentPath }} className="text-foreground hover:underline">
+                        {truncate(volumeName, 24)}
+                      </NavLink>
+                    ) : (
+                      truncate(volumeName, 24)
+                    )}
+                  </div>
+                  <span className="text-xs text-muted-foreground" data-testid="workload-thread-storage-size">
+                    {sizeLabel}
+                  </span>
+                  <span className="text-xs text-muted-foreground" data-testid="workload-thread-storage-attached">
+                    {attachedLabel}
+                  </span>
+                  <Badge variant={resolveVolumeVariant(volume.status)} data-testid="workload-thread-storage-status">
+                    {formatVolumeStatus(volume.status)}
+                  </Badge>
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+        <LoadMoreButton
+          hasMore={Boolean(volumesQuery.hasNextPage)}
+          isLoading={volumesQuery.isFetchingNextPage}
+          onClick={() => {
+            void volumesQuery.fetchNextPage();
+          }}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
 export function WorkloadDetailPage() {
   const { id: organizationIdParam, workloadId: workloadIdParam } = useParams();
   const organizationId = organizationIdParam ?? '';
@@ -278,6 +361,28 @@ export function WorkloadDetailPage() {
   });
 
   const workload = workloadQuery.data?.workload ?? null;
+
+  const volumesQuery = useInfiniteQuery({
+    queryKey: ['workloads', workloadId, 'thread-volumes', workload?.threadId ?? ''],
+    queryFn: ({ pageParam }) => {
+      if (!workload) throw new Error('Workload is required before loading thread storage.');
+      return runnersClient.listVolumesByThread({
+        threadId: workload.threadId,
+        pageSize: DEFAULT_PAGE_SIZE,
+        pageToken: pageParam,
+      });
+    },
+    initialPageParam: '',
+    getNextPageParam: (lastPage) => lastPage.nextPageToken || undefined,
+    enabled: Boolean(workload?.threadId),
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const volumes = useMemo(
+    () => volumesQuery.data?.pages.flatMap((page) => page.volumes) ?? [],
+    [volumesQuery.data?.pages],
+  );
   const isNotFoundError = workloadQuery.error instanceof ConnectError && workloadQuery.error.code === Code.NotFound;
   const isOrgMismatch = Boolean(workload && organizationId && workload.organizationId !== organizationId);
   const isMissing = !workload && !workloadQuery.isPending && !workloadQuery.isError;
@@ -286,6 +391,20 @@ export function WorkloadDetailPage() {
 
   const workloadTitle = workload?.meta?.id ? `Workload ${truncate(workload.meta.id, 12)}` : 'Workload';
   useDocumentTitle(workloadTitle);
+
+  const volumeNotificationRooms = useMemo(() => {
+    const rooms: string[] = [];
+    if (organizationId) rooms.push(`organization:${organizationId}`);
+    if (workload?.threadId) rooms.push(`thread:${workload.threadId}`);
+    return rooms;
+  }, [organizationId, workload?.threadId]);
+
+  useNotifications({
+    events: ['volume.updated'],
+    invalidateKeys: [['workloads', workloadId, 'thread-volumes', workload?.threadId ?? '']],
+    rooms: volumeNotificationRooms,
+    enabled: Boolean(workload?.threadId) && volumeNotificationRooms.length > 0,
+  });
 
   const containers = workload?.containers ?? [];
   const sortedContainers = [...containers].sort((left, right) => {
@@ -452,6 +571,12 @@ export function WorkloadDetailPage() {
               </div>
             </CardContent>
           </Card>
+          <ThreadStoragePanel
+            currentPath={location.pathname}
+            organizationId={organizationId}
+            volumes={volumes}
+            volumesQuery={volumesQuery}
+          />
           <div className="space-y-3" data-testid="workload-container-section">
             <div>
               <h3 className="text-lg font-semibold text-foreground">Containers</h3>


### PR DESCRIPTION
## Summary
- Add an Associated workloads section to thread detail pages using `ListWorkloadsByThread` with pagination and workload notification refresh.
- Add an Attached storage section to workload detail pages using `ListVolumesByThread` after loading the workload thread ID.
- Share volume attachment labeling/summarization for list/detail views and add coverage for `+N more` summaries.

Closes #113

## Verification
- `npm run typecheck` — passed
- `npm run lint` — passed with no errors
- `npm test` — 22 files passed, 95 tests passed, 0 failed, 0 skipped
- `npm run build` — passed