### PR TITLE
ci(e2e): update bootstrap provision pin

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@adf1dc4453de5934a9bae8c0f03f7b417e472d79
+        uses: agynio/bootstrap/.github/actions/provision@84cfcd81fe303450baacb8ab499bb065851ee4ad
+        with:
+          ref: 84cfcd81fe303450baacb8ab499bb065851ee4ad
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main


### PR DESCRIPTION
## Summary
- Updates the E2E bootstrap provision action from the older pinned SHA to current bootstrap commit `84cfcd81fe303450baacb8ab499bb065851ee4ad`.
- Passes the same SHA via the action's `ref` input so the action metadata and checked-out bootstrap scripts stay self-consistent.
- Uses the bootstrap action version that includes the `Install OpenZiti CLI` step, satisfying the `ziti` CLI requirement without adding long-lived secrets.

Closes #120

## Verification
- `PATH=/tmp/node-v20.20.2-linux-arm64/bin:$PATH npm run lint` — passed, no lint errors.
- `PATH=/tmp/node-v20.20.2-linux-arm64/bin:$PATH npm run typecheck` — passed, no type errors.
- `PATH=/tmp/node-v20.20.2-linux-arm64/bin:$PATH npm test` — 95 passed, 0 failed, 0 skipped.
- `PATH=/tmp/node-v20.20.2-linux-arm64/bin:$PATH npm run build` — passed.
- `/tmp/go-bin/actionlint .github/workflows/e2e.yml` — passed, no workflow lint errors.
- `git diff --check` — passed, no whitespace errors.

Notes:
- I checked `agynio/architecture` first; the E2E architecture keeps cluster-level tooling inside `agynio/bootstrap/.github/actions/provision` and allows a `ref` input for the bootstrap checkout.
- `npm run generate` was checked during verification, but the current remote API descriptors generate changes outside this issue's scope, so those generated files were not committed.