### PR TITLE
fix: stop subscribing to a room nothing publishes

### DIFF
--- a/src/pages/OrganizationThreadDetailPage.tsx
+++ b/src/pages/OrganizationThreadDetailPage.tsx
@@ -161,12 +161,14 @@ export function OrganizationThreadDetailPage() {
   const isThreadLoading = threadQuery.isPending;
   const isThreadError = threadQuery.isError;
 
+  // Only the organization room. Nothing in the platform publishes to
+  // "thread:{id}" -- that room came from platform.v1, and the workload events
+  // below arrive on the organization room.
   const notificationRooms = useMemo(() => {
     const rooms: string[] = [];
     if (organizationId) rooms.push(`organization:${organizationId}`);
-    if (resolvedThreadId) rooms.push(`thread:${resolvedThreadId}`);
     return rooms;
-  }, [organizationId, resolvedThreadId]);
+  }, [organizationId]);
 
   useNotifications({
     events: ['workload.status_changed', 'workload.updated'],

--- a/src/pages/WorkloadDetailPage.tsx
+++ b/src/pages/WorkloadDetailPage.tsx
@@ -392,12 +392,13 @@ export function WorkloadDetailPage() {
   const workloadTitle = workload?.meta?.id ? `Workload ${truncate(workload.meta.id, 12)}` : 'Workload';
   useDocumentTitle(workloadTitle);
 
+  // Only the organization room -- see OrganizationThreadDetailPage: no
+  // publisher exists for "thread:{id}".
   const volumeNotificationRooms = useMemo(() => {
     const rooms: string[] = [];
     if (organizationId) rooms.push(`organization:${organizationId}`);
-    if (workload?.threadId) rooms.push(`thread:${workload.threadId}`);
     return rooms;
-  }, [organizationId, workload?.threadId]);
+  }, [organizationId]);
 
   useNotifications({
     events: ['volume.updated'],


### PR DESCRIPTION
Both pages subscribe to `thread:{id}` alongside `organization:{id}`. `thread:` is a **platform.v1** room — no Go service publishes to it, and it is absent from the room table in `architecture/notifications.md`. The `workload.*` / `volume.updated` events these pages invalidate on arrive via the organization room they already hold.

This is a prerequisite, not just cleanup. A `Subscribe` call is authorized as a unit, so when Notifications starts refusing rooms it cannot resolve a caller's access to ([authz.md — Notifications Service](https://github.com/agynio/architecture/blob/main/architecture/authz.md)), this one dead room would deny both pages their whole stream.