### PR TITLE
fix(console): drop the page headers that repeat the header bar

### DIFF
--- a/src/pages/OrganizationActivityStorageTab.tsx
+++ b/src/pages/OrganizationActivityStorageTab.tsx
@@ -281,12 +281,6 @@ export function OrganizationActivityStorageTab() {
 
   return (
     <div className="space-y-4" data-testid="organization-activity-storage">
-      <div className="space-y-2">
-        <h3 className="text-base font-semibold text-foreground">Storage</h3>
-        <p className="text-sm text-muted-foreground">
-          Real-time view of persistent volumes in use across the organization.
-        </p>
-      </div>
       <FilterBar isActive={hasActiveFilters} onClear={clearFilters} testId="organization-storage-filters">
         <Input
           className="w-full max-w-xs sm:w-64"

--- a/src/pages/OrganizationActivityWorkloadsTab.tsx
+++ b/src/pages/OrganizationActivityWorkloadsTab.tsx
@@ -320,12 +320,6 @@ export function OrganizationActivityWorkloadsTab() {
 
   return (
     <div className="space-y-6" data-testid="organization-activity-workloads">
-      <div className="space-y-2">
-        <h3 className="text-base font-semibold text-foreground">Workloads</h3>
-        <p className="text-sm text-muted-foreground">
-          Real-time view of running agent workloads in the organization.
-        </p>
-      </div>
       <WorkloadsTable
         workloads={workloads}
         query={workloadsQuery}

--- a/src/pages/OrganizationUsageTab.tsx
+++ b/src/pages/OrganizationUsageTab.tsx
@@ -780,27 +780,19 @@ export function OrganizationUsageTab() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center justify-between gap-4" data-testid="organization-usage-header">
-        <div>
-          <h2 className="text-base font-semibold text-foreground">Usage dashboard</h2>
-          <p className="text-sm text-muted-foreground">
-            Monitor consumption across LLM, compute, storage, and platform activity.
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-3" data-testid="organization-usage-range-select">
-          <Select value={rangeOption} onValueChange={(value) => setRangeOption(value as RangeOption)}>
-            <SelectTrigger>
-              <SelectValue placeholder="Select range" />
-            </SelectTrigger>
-            <SelectContent>
-              {rangeOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+      <div className="flex flex-wrap items-center gap-3" data-testid="organization-usage-header">
+        <Select value={rangeOption} onValueChange={(value) => setRangeOption(value as RangeOption)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select range" />
+          </SelectTrigger>
+          <SelectContent>
+            {rangeOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
       {rangeOption === 'custom' ? (
         <div className="flex flex-wrap items-center gap-3" data-testid="organization-usage-custom-range">


### PR DESCRIPTION
Workloads, Provisioned Storage and Usage opened with a heading and description restating the title the layout header bar already shows. The other 24 navigable pages open straight into their search/filter row.

| Page | Removed |
|---|---|
| Workloads | **Workloads** — "Real-time view of running agent workloads in the organization." |
| Provisioned Storage | **Storage** — "Real-time view of persistent volumes in use across the organization." |
| Usage | **Usage dashboard** — "Monitor consumption across LLM, compute, storage, and platform activity." |

Storage's heading also still said "Storage" after the section was renamed to Provisioned Storage, so it disagreed with the sidebar and the header bar both.

Usage keeps its range selector on that row, and `organization-usage-header` with it — three e2e specs assert that id. The inner `organization-usage-range-select` wrapper went with the heading; nothing referenced it.

Left alone deliberately: **Runners** has two headings ("Organization Runners", "Cluster Runners") that distinguish two lists on one page rather than repeat the title, and **Apps** uses tabs. Detail-page card headings ("Details", "Attachments", "Containers") sit under a page title that is an entity name, so they are not duplicates either.