### PR TITLE
Request a SHELL session from the browser terminal

### DIFF
--- a/src/__tests__/organization-sandboxes-tab.test.tsx
+++ b/src/__tests__/organization-sandboxes-tab.test.tsx
@@ -1,3 +1,4 @@
+import { SessionKind } from '@/gen/agynio/api/terminal_proxy/v1/terminal_proxy_pb';
 import { create } from '@bufbuild/protobuf';
 import { timestampFromDate } from '@bufbuild/protobuf/wkt';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -258,6 +259,7 @@ describe('SandboxTerminal', () => {
       expect(createTerminalSession).toHaveBeenCalledWith({
         workloadId: 'workload-1',
         containerName: 'main',
+        kind: SessionKind.SHELL,
       });
     });
 

--- a/src/__tests__/terminal-session-kind.test.ts
+++ b/src/__tests__/terminal-session-kind.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { SessionKind } from '@/gen/agynio/api/terminal_proxy/v1/terminal_proxy_pb';
+
+const { createTerminalSession } = vi.hoisted(() => ({ createTerminalSession: vi.fn() }));
+
+vi.mock('@/api/client', () => ({
+  terminalClient: { createTerminalSession },
+}));
+
+// An unspecified kind is rejected rather than defaulted, so the browser
+// terminal has to name the one it wants. Omitting it broke the Console's
+// terminal with "kind is required".
+describe('terminal session', () => {
+  beforeEach(() => {
+    createTerminalSession.mockReset();
+    createTerminalSession.mockResolvedValue({ ticket: '', websocketUrl: '' });
+  });
+
+  it('requests a SHELL session', async () => {
+    const { TerminalSession } = await import('@/lib/terminalSession');
+    const session = new TerminalSession({ onError: vi.fn(), onData: vi.fn() });
+    await session.open({ workloadId: 'w', containerName: 'main' });
+
+    expect(createTerminalSession).toHaveBeenCalledTimes(1);
+    expect(createTerminalSession.mock.calls[0][0]).toMatchObject({
+      workloadId: 'w',
+      containerName: 'main',
+      kind: SessionKind.SHELL,
+    });
+    expect(createTerminalSession.mock.calls[0][0].kind).not.toBe(SessionKind.UNSPECIFIED);
+  });
+});

--- a/src/lib/terminalSession.ts
+++ b/src/lib/terminalSession.ts
@@ -1,4 +1,5 @@
 import { terminalClient } from '@/api/client';
+import { SessionKind } from '@/gen/agynio/api/terminal_proxy/v1/terminal_proxy_pb';
 
 /**
  * Browser client for the Terminal Proxy wire protocol, mirroring the CLI's
@@ -104,6 +105,9 @@ export class TerminalSession {
       const session = await terminalClient.createTerminalSession({
         workloadId: target.workloadId,
         containerName: target.containerName,
+        // Required. An unspecified kind is rejected rather than defaulted, so
+        // the browser terminal has to name the one it wants.
+        kind: SessionKind.SHELL,
       });
       ticket = session.ticket;
       websocketUrl = session.websocketUrl;


### PR DESCRIPTION
The Console's terminal is broken on `main`:

> `[invalid_argument] kind is required`

`CreateTerminalSession` now takes a session kind (agynio/api#175), and an unspecified one is **rejected** rather than defaulted — silently defaulting the field that selects a command is how an unintended command ends up in a ticket. The Console kept sending none.

This was a known consequence of the proto change and I failed to make it: the plan said "Console: send `kind: SHELL` explicitly", the API shipped, and the Console was never updated.

- `terminalSession.ts` sends `SessionKind.SHELL`
- generated protos refreshed from the BSR
- a test asserts the kind is SHELL and not UNSPECIFIED; reverting the fix makes it fail
- the existing `organization-sandboxes-tab` assertion is updated for the new field

Full suite: 164 passed, `tsc --noEmit` clean.