### PR TITLE
Say what the organization is doing on its Overview

### DIFF
--- a/src/__tests__/organization-overview.test.tsx
+++ b/src/__tests__/organization-overview.test.tsx
@@ -1,0 +1,278 @@
+import { create } from '@bufbuild/protobuf';
+import { TimestampSchema } from '@bufbuild/protobuf/wkt';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PageTitleProvider } from '@/context/PageTitleContext';
+import { Granularity, Unit } from '@/gen/agynio/api/metering/v1/metering_pb';
+import { RuntimeOwnerKind, WorkloadStatus } from '@/gen/agynio/api/runners/v1/runners_pb';
+import { OrganizationOverviewTab } from '@/pages/OrganizationOverviewTab';
+
+const mocks = vi.hoisted(() => ({
+  listMembers: vi.fn(),
+  listSecretProviders: vi.fn(),
+  listSecrets: vi.fn(),
+  listRunners: vi.fn(),
+  listWorkloads: vi.fn(),
+  listAgents: vi.fn(),
+  listSandboxes: vi.fn(),
+  listInstallations: vi.fn(),
+  listOrganizationThreads: vi.fn(),
+  getMessages: vi.fn(),
+  queryUsage: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  organizationsClient: { listMembers: mocks.listMembers },
+  secretsClient: { listSecretProviders: mocks.listSecretProviders, listSecrets: mocks.listSecrets },
+  runnersClient: { listRunners: mocks.listRunners, listWorkloads: mocks.listWorkloads },
+  agentsClient: { listAgents: mocks.listAgents, listSandboxes: mocks.listSandboxes },
+  appsClient: { listInstallations: mocks.listInstallations },
+  threadsClient: {
+    listOrganizationThreads: mocks.listOrganizationThreads,
+    getMessages: mocks.getMessages,
+  },
+  meteringClient: { queryUsage: mocks.queryUsage },
+}));
+
+vi.mock('@/context/OrganizationContext', () => ({
+  useOrganizationContext: () => ({ organizations: [{ id: 'org-1', name: 'Acme' }] }),
+}));
+
+vi.mock('@/hooks/useNotifications', () => ({ useNotifications: () => {} }));
+
+const HOUR_MS = 3_600_000;
+
+/** Metering reports every value in micros. */
+function micros(value: number): bigint {
+  return BigInt(value) * 1_000_000n;
+}
+
+function agoTimestamp(millisAgo: number) {
+  return create(TimestampSchema, {
+    seconds: BigInt(Math.floor((Date.now() - millisAgo) / 1000)),
+    nanos: 0,
+  });
+}
+
+/** Local midnight, `daysAgo` days back, which is how metering buckets a day. */
+function dayTimestamp(daysAgo: number) {
+  const day = new Date();
+  day.setHours(0, 0, 0, 0);
+  return agoTimestamp(Date.now() - day.getTime() + daysAgo * 24 * HOUR_MS);
+}
+
+function renderOverview() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <PageTitleProvider>
+        <MemoryRouter initialEntries={['/organizations/org-1']}>
+          <Routes>
+            <Route path="/organizations/:id" element={<OrganizationOverviewTab />} />
+            <Route path="/organizations/:id/setup" element={<div>setup wizard</div>} />
+          </Routes>
+        </MemoryRouter>
+      </PageTitleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('OrganizationOverviewTab dashboard', () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    Object.values(mocks).forEach((mock) => mock.mockReset());
+    window.localStorage.clear();
+
+    mocks.listMembers.mockResolvedValue({ memberships: [{ id: 'm-1' }] });
+    mocks.listSecretProviders.mockResolvedValue({ secretProviders: [] });
+    mocks.listSecrets.mockResolvedValue({ secrets: [] });
+    mocks.listRunners.mockResolvedValue({ runners: [{ id: 'runner-1' }] });
+    mocks.listWorkloads.mockResolvedValue({ workloads: [] });
+    // An organization with an agent is past setup, which is what puts the
+    // dashboard on screen rather than a redirect to the wizard.
+    mocks.listAgents.mockResolvedValue({ agents: [{ meta: { id: 'agent-1' }, name: 'Assistant' }] });
+    mocks.listSandboxes.mockResolvedValue({ sandboxes: [] });
+    mocks.listInstallations.mockResolvedValue({ installations: [] });
+    mocks.listOrganizationThreads.mockResolvedValue({ threads: [] });
+    mocks.getMessages.mockResolvedValue({ messages: [] });
+    mocks.queryUsage.mockResolvedValue({ buckets: [] });
+  });
+
+  it('reads tokens, compute and threads over the last week', async () => {
+    mocks.queryUsage.mockImplementation(async (request: { unit: Unit; labelFilters?: Record<string, string> }) => {
+      if (request.unit === Unit.TOKENS) return { buckets: [{ value: micros(128_000) }] };
+      if (request.unit === Unit.FLAVOR_SECONDS) return { buckets: [{ value: micros(9_000) }] };
+      if (request.labelFilters?.kind === 'thread') return { buckets: [{ value: micros(6) }] };
+      if (request.labelFilters?.kind === 'message') return { buckets: [{ value: micros(42) }] };
+      return { buckets: [] };
+    });
+
+    renderOverview();
+
+    const tokens = await screen.findByTestId('organization-overview-tokens');
+    await waitFor(() => expect(tokens.textContent).toContain('128K'));
+    expect(screen.getByTestId('organization-overview-compute').textContent).toContain('2.5h');
+    expect(screen.getByTestId('organization-overview-compute').textContent).toContain('across 1 runner');
+    const threads = screen.getByTestId('organization-overview-threads');
+    expect(threads.textContent).toContain('6');
+    expect(threads.textContent).toContain('42 messages');
+  });
+
+  it('compares the week against the one before it', async () => {
+    // Both windows end where the other begins, so the earlier request is the
+    // one whose start is further back.
+    mocks.queryUsage.mockImplementation(async (request: { unit: Unit; start?: { seconds: bigint } }) => {
+      if (request.unit !== Unit.TOKENS) return { buckets: [] };
+      const startedAt = Number(request.start?.seconds ?? 0n) * 1000;
+      const isPreviousWeek = Date.now() - startedAt > 8 * 24 * HOUR_MS;
+      return { buckets: [{ value: micros(isPreviousWeek ? 41_000 : 128_000) }] };
+    });
+
+    renderOverview();
+
+    const trend = await screen.findByTestId('organization-overview-token-trend');
+    expect(trend.textContent).toContain('vs 41K the week before');
+  });
+
+  it('charts only the days a new organization could have used', async () => {
+    // Two days of usage in a seven-day window: the five empty days before them
+    // are days this organization did not exist for, not days it was idle.
+    mocks.queryUsage.mockImplementation(async (request: { granularity: Granularity; unit: Unit }) => {
+      if (request.unit !== Unit.TOKENS || request.granularity !== Granularity.DAY) {
+        return { buckets: [] };
+      }
+      return {
+        buckets: [
+          { value: micros(246_326), timestamp: dayTimestamp(1) },
+          { value: micros(217_874), timestamp: dayTimestamp(0) },
+        ],
+      };
+    });
+
+    renderOverview();
+
+    const chart = await screen.findByTestId('organization-overview-token-chart');
+    await waitFor(() => expect(chart.textContent).toContain('Last 3 days'));
+    expect(chart.textContent).not.toContain('Last 7 days');
+  });
+
+  it('charts the whole week once there is a whole week of it', async () => {
+    mocks.queryUsage.mockImplementation(async (request: { granularity: Granularity; unit: Unit }) => {
+      if (request.unit !== Unit.TOKENS || request.granularity !== Granularity.DAY) {
+        return { buckets: [] };
+      }
+      return {
+        buckets: Array.from({ length: 7 }, (_, index) => ({
+          value: micros(1_000),
+          timestamp: dayTimestamp(index),
+        })),
+      };
+    });
+
+    renderOverview();
+
+    const chart = await screen.findByTestId('organization-overview-token-chart');
+    await waitFor(() => expect(chart.textContent).toContain('Last 7 days'));
+  });
+
+  it('says so when there is nothing to chart', async () => {
+    renderOverview();
+
+    await screen.findByTestId('organization-overview-token-chart');
+    await waitFor(() =>
+      expect(screen.getByTestId('organization-overview-token-chart').textContent).toContain(
+        'No model calls in the last 7 days',
+      ),
+    );
+  });
+
+  it('treats a deployment without metering as no usage', async () => {
+    mocks.queryUsage.mockRejectedValue(new ConnectError('no metering', Code.Unimplemented));
+
+    renderOverview();
+
+    await screen.findByTestId('organization-overview-token-chart');
+    await waitFor(() =>
+      expect(screen.getByTestId('organization-overview-token-chart').textContent).toContain(
+        'No model calls',
+      ),
+    );
+    expect(screen.getByTestId('organization-overview-tokens').textContent).toContain('0');
+  });
+
+  it('lists what is running with how long it has been up', async () => {
+    mocks.listWorkloads.mockResolvedValue({
+      workloads: [
+        {
+          meta: { id: 'wl-1', createdAt: agoTimestamp(3 * HOUR_MS) },
+          status: WorkloadStatus.RUNNING,
+          ownerKind: RuntimeOwnerKind.AGENT_INSTANCE,
+          ownerName: 'Assistant',
+        },
+      ],
+    });
+
+    renderOverview();
+
+    const row = await screen.findByTestId('organization-overview-running-row');
+    expect(row.textContent).toContain('Assistant');
+    expect(row.textContent).toContain('3h');
+  });
+
+  it('opens each recent thread with its first message and its age', async () => {
+    mocks.listOrganizationThreads.mockResolvedValue({
+      threads: [{ id: 'thread-1', updatedAt: agoTimestamp(26 * HOUR_MS) }],
+    });
+    mocks.getMessages.mockResolvedValue({
+      messages: [
+        {
+          id: 'msg-1',
+          body: `Review the retry logic in the ingest worker\n${'and say what breaks under load '.repeat(4)}`,
+        },
+      ],
+    });
+
+    renderOverview();
+
+    const row = await screen.findByTestId('organization-overview-thread-row');
+    await waitFor(() => expect(row.textContent).toContain('Review the retry logic in the ingest worker'));
+    // Truncated to one line, and dated in a single unit.
+    expect(row.textContent).toContain('...');
+    expect(row.textContent).not.toContain('\n');
+    expect(row.textContent).toContain('1d');
+  });
+
+  it('asks for the oldest message first, since that is the one that opens the thread', async () => {
+    mocks.listOrganizationThreads.mockResolvedValue({
+      threads: [{ id: 'thread-1', updatedAt: agoTimestamp(HOUR_MS) }],
+    });
+
+    renderOverview();
+
+    await waitFor(() => expect(mocks.getMessages).toHaveBeenCalled());
+    expect(mocks.getMessages.mock.calls[0][0]).toMatchObject({ threadId: 'thread-1', pageSize: 1 });
+  });
+
+  it('hides the threads panel from a member who may not list them', async () => {
+    mocks.listOrganizationThreads.mockRejectedValue(new ConnectError('nope', Code.PermissionDenied));
+
+    renderOverview();
+
+    await screen.findByTestId('organization-overview-running');
+    await waitFor(() => expect(screen.queryByTestId('organization-overview-threads-panel')).toBeNull());
+  });
+
+  it('keeps the counters as links', async () => {
+    renderOverview();
+
+    const summary = await screen.findByTestId('organization-overview-summary');
+    const links = screen.getAllByTestId('organization-overview-card-link');
+    expect(summary).toBeTruthy();
+    expect(links).toHaveLength(7);
+    expect(links[1].getAttribute('href')).toBe('/organizations/org-1/agents');
+  });
+});

--- a/src/__tests__/setup-wizard-entry.test.tsx
+++ b/src/__tests__/setup-wizard-entry.test.tsx
@@ -16,6 +16,9 @@ const mocks = vi.hoisted(() => ({
   listAgents: vi.fn(),
   listSandboxes: vi.fn(),
   listInstallations: vi.fn(),
+  listOrganizationThreads: vi.fn(),
+  getMessages: vi.fn(),
+  queryUsage: vi.fn(),
 }));
 
 const organizations = vi.hoisted(() => ({ current: [] as { id: string; name: string }[] }));
@@ -26,6 +29,11 @@ vi.mock('@/api/client', () => ({
   runnersClient: { listRunners: mocks.listRunners, listWorkloads: mocks.listWorkloads },
   agentsClient: { listAgents: mocks.listAgents, listSandboxes: mocks.listSandboxes },
   appsClient: { listInstallations: mocks.listInstallations },
+  threadsClient: {
+    listOrganizationThreads: mocks.listOrganizationThreads,
+    getMessages: mocks.getMessages,
+  },
+  meteringClient: { queryUsage: mocks.queryUsage },
 }));
 
 vi.mock('@/context/OrganizationContext', () => ({
@@ -107,6 +115,9 @@ describe('setup wizard entry points', () => {
     mocks.listAgents.mockResolvedValue({ agents: [] });
     mocks.listSandboxes.mockResolvedValue({ sandboxes: [] });
     mocks.listInstallations.mockResolvedValue({ installations: [] });
+    mocks.listOrganizationThreads.mockResolvedValue({ threads: [] });
+    mocks.getMessages.mockResolvedValue({ messages: [] });
+    mocks.queryUsage.mockResolvedValue({ buckets: [] });
   });
 
   it('starts setup on the first organization a user creates', async () => {

--- a/src/components/ChartTooltip.tsx
+++ b/src/components/ChartTooltip.tsx
@@ -1,0 +1,30 @@
+import type { TooltipContentProps } from 'recharts';
+
+// Partial because recharts injects these when it clones the element, so the
+// call site passes none of them.
+type ChartTooltipProps = Partial<TooltipContentProps<number, string>> & {
+  /** Turns a series value into what the tooltip should say about it. */
+  format?: (value: number) => string;
+};
+
+/**
+ * Recharts' own tooltip is inline-styled — a white box with a grey border and
+ * series-coloured text — so it ignores the theme and looks foreign in dark mode.
+ */
+export function ChartTooltip({ active, payload, label, format }: ChartTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div className="rounded-md border border-border bg-popover px-2.5 py-1.5 shadow-md">
+      <div className="text-xs text-muted-foreground">{String(label ?? '')}</div>
+      {payload.map((entry, index) => {
+        const value = typeof entry.value === 'number' ? entry.value : Number(entry.value ?? 0);
+        return (
+          <div key={index} className="text-sm font-medium text-popover-foreground">
+            {format ? format(value) : value.toLocaleString()}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -39,7 +39,8 @@ export function formatDateOnly(timestamp?: Timestamp | null): string {
   return formatTimestamp(timestamp, { dateStyle: 'medium' });
 }
 
-export function formatDuration(milliseconds: number): string {
+/** maxParts=1 gives the single coarsest unit, which is how an age reads in a list. */
+export function formatDuration(milliseconds: number, maxParts = 2): string {
   if (!Number.isFinite(milliseconds) || milliseconds <= 0) return EMPTY_PLACEHOLDER;
   let remainingSeconds = Math.max(1, Math.floor(milliseconds / 1000));
   const units = [
@@ -51,7 +52,7 @@ export function formatDuration(milliseconds: number): string {
   const parts: string[] = [];
 
   for (const unit of units) {
-    if (parts.length >= 2) break;
+    if (parts.length >= maxParts) break;
     if (remainingSeconds < unit.seconds && unit.label !== 's') continue;
     const value = Math.floor(remainingSeconds / unit.seconds);
     if (value <= 0) continue;
@@ -62,14 +63,27 @@ export function formatDuration(milliseconds: number): string {
   return parts.length > 0 ? parts.join(' ') : EMPTY_PLACEHOLDER;
 }
 
-export function formatDurationBetween(start?: Timestamp | null, end?: Timestamp | null): string {
+export function formatDurationBetween(
+  start?: Timestamp | null,
+  end?: Timestamp | null,
+  maxParts = 2,
+): string {
   if (!start) return EMPTY_PLACEHOLDER;
   const startMillis = timestampToMillis(start);
   if (!startMillis) return EMPTY_PLACEHOLDER;
   const endMillis = end ? timestampToMillis(end) : Date.now();
   if (!endMillis) return EMPTY_PLACEHOLDER;
   const duration = Math.max(0, endMillis - startMillis);
-  return formatDuration(duration);
+  return formatDuration(duration, maxParts);
+}
+
+/** How long ago, in one unit. Anything under a minute is not worth a number. */
+export function formatAge(timestamp?: Timestamp | null): string {
+  if (!timestamp) return EMPTY_PLACEHOLDER;
+  const millis = timestampToMillis(timestamp);
+  if (!millis) return EMPTY_PLACEHOLDER;
+  if (Date.now() - millis < 60_000) return 'just now';
+  return formatDurationBetween(timestamp, null, 1);
 }
 
 export function formatLabelPairs(labels: Record<string, string>): string {

--- a/src/lib/metering.ts
+++ b/src/lib/metering.ts
@@ -1,0 +1,59 @@
+import { create } from '@bufbuild/protobuf';
+import { TimestampSchema, type Timestamp } from '@bufbuild/protobuf/wkt';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { meteringClient } from '@/api/client';
+import {
+  QueryUsageResponseSchema,
+  type Granularity,
+  type QueryUsageResponse,
+  type Unit,
+  type UsageBucket,
+} from '@/gen/agynio/api/metering/v1/metering_pb';
+
+export function toTimestamp(date: Date): Timestamp {
+  return create(TimestampSchema, {
+    seconds: BigInt(Math.floor(date.getTime() / 1000)),
+    nanos: 0,
+  });
+}
+
+/** Metering is optional in a deployment, which reads as no data rather than a failure. */
+export function isUsageUnavailable(error: unknown): boolean {
+  return error instanceof ConnectError && (error.code === Code.Unimplemented || error.code === Code.NotFound);
+}
+
+export type UsageQuery = {
+  organizationId: string;
+  start: Date;
+  end: Date;
+  unit: Unit;
+  granularity: Granularity;
+  labelFilters?: Record<string, string>;
+  groupBy?: string;
+  timeZone?: string;
+};
+
+/** Reads usage, reporting an absent metering service as an empty series. */
+export async function queryUsage(query: UsageQuery): Promise<QueryUsageResponse> {
+  try {
+    return await meteringClient.queryUsage({
+      orgId: query.organizationId,
+      start: toTimestamp(query.start),
+      end: toTimestamp(query.end),
+      unit: query.unit,
+      labelFilters: query.labelFilters ?? {},
+      groupBy: query.groupBy ?? '',
+      granularity: query.granularity,
+      timeZone: query.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+    });
+  } catch (error) {
+    if (isUsageUnavailable(error)) {
+      return create(QueryUsageResponseSchema, { buckets: [] });
+    }
+    throw error;
+  }
+}
+
+export function sumUsageBuckets(buckets: UsageBucket[]): bigint {
+  return buckets.reduce((total, bucket) => total + bucket.value, 0n);
+}

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -6,6 +6,7 @@ const SECONDS_PER_HOUR = 3600;
 const usageFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });
 const hoursFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });
 const hoursSmallFormatter = new Intl.NumberFormat('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+const compactFormatter = new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 });
 
 export function microsToNumber(value: bigint): number {
   return Number(value) / MICRO_UNITS;
@@ -26,6 +27,15 @@ export function formatUsageHoursNumber(value?: number | null): string {
     return hoursSmallFormatter.format(value);
   }
   return hoursFormatter.format(value);
+}
+
+/** For a headline figure, where the exact token count says less than its size. */
+export function formatUsageCompact(value?: bigint | null): string {
+  if (value === null || value === undefined) return EMPTY_PLACEHOLDER;
+  const number = microsToNumber(value);
+  if (!Number.isFinite(number)) return EMPTY_PLACEHOLDER;
+  if (number < 1000) return usageFormatter.format(number);
+  return compactFormatter.format(number);
 }
 
 export function formatUsageValue(value?: bigint | null): string {

--- a/src/pages/OrganizationOverviewTab.tsx
+++ b/src/pages/OrganizationOverviewTab.tsx
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query';
 import { CopyIcon } from 'lucide-react';
 import { agentsClient, appsClient, organizationsClient, runnersClient, secretsClient } from '@/api/client';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useOrganizationContext } from '@/context/OrganizationContext';
 import { MembershipStatus } from '@/gen/agynio/api/organizations/v1/organizations_pb';
 import { WorkloadStatus } from '@/gen/agynio/api/runners/v1/runners_pb';
@@ -12,6 +11,9 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useNotifications } from '@/hooks/useNotifications';
 import { copyText } from '@/lib/clipboard';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
+import { OverviewActivity } from '@/pages/overview/OverviewActivity';
+import { RecentThreads } from '@/pages/overview/RecentThreads';
+import { RunningNow } from '@/pages/overview/RunningNow';
 import { isSetupSkipped } from '@/pages/setup/skipped';
 
 export function OrganizationOverviewTab() {
@@ -146,57 +148,67 @@ export function OrganizationOverviewTab() {
 
   return (
     <div className="space-y-4">
-      <Card className="border-border" data-testid="organization-overview-identity">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">
-            {organizationName || 'Organization'}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-xs uppercase tracking-wide text-muted-foreground">Organization ID</div>
-              <div
-                className="mt-1 font-mono text-sm break-all text-foreground"
-                data-testid="organization-overview-id"
-              >
-                {organizationId}
-              </div>
-              <p className="mt-1 text-xs text-muted-foreground">
-                The <code className="font-mono">organization_id</code> required by the Terraform provider and the API.
-              </p>
+      {/* The identity is a lookup, not a headline: it earns a row, and the
+          activity below it earns the rest of the page. */}
+      <div
+        className="flex flex-wrap items-start justify-between gap-3"
+        data-testid="organization-overview-identity"
+      >
+        <h2 className="text-lg font-semibold text-foreground">{organizationName || 'Organization'}</h2>
+        <div className="flex items-center gap-2">
+          <div className="text-right">
+            <div className="font-mono text-xs break-all text-muted-foreground" data-testid="organization-overview-id">
+              {organizationId}
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => copyText(organizationId, 'Organization ID copied.')}
-              data-testid="organization-overview-id-copy"
-            >
-              <CopyIcon className="h-4 w-4" />
-              Copy ID
-            </Button>
+            <p className="text-xs text-muted-foreground">
+              The <code className="font-mono">organization_id</code> the Terraform provider and the API take.
+            </p>
           </div>
-        </CardContent>
-      </Card>
-      <div className="grid gap-4 md:grid-cols-2" data-testid="organization-overview-summary">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => copyText(organizationId, 'Organization ID copied.')}
+            data-testid="organization-overview-id-copy"
+          >
+            <CopyIcon className="h-4 w-4" />
+            Copy ID
+          </Button>
+        </div>
+      </div>
+
+      <OverviewActivity
+        organizationId={organizationId}
+        runnerCount={runnersQuery.data?.runners.length ?? 0}
+      />
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <RunningNow
+          organizationId={organizationId}
+          workloads={workloadsQuery.data?.workloads ?? []}
+          isPending={workloadsQuery.isPending}
+          isError={workloadsQuery.isError}
+        />
+        <RecentThreads organizationId={organizationId} />
+      </div>
+
+      {/* The counters keep their links; they no longer keep the page. */}
+      <div
+        className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-7"
+        data-testid="organization-overview-summary"
+      >
         {summary.map((item) => (
           <NavLink
             key={item.label}
             to={item.to}
-            className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="rounded-lg border border-border bg-card px-3 py-2 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             data-testid="organization-overview-card-link"
           >
-            <Card
-              className="cursor-pointer border-border transition-colors hover:bg-muted"
-              data-testid="organization-overview-card"
-            >
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm font-medium text-muted-foreground">{item.label}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-semibold text-foreground">{item.value}</div>
-              </CardContent>
-            </Card>
+            <div className="truncate text-xs text-muted-foreground" title={item.label}>
+              {item.label}
+            </div>
+            <div className="text-lg font-semibold text-foreground" data-testid="organization-overview-card">
+              {item.value}
+            </div>
           </NavLink>
         ))}
       </div>

--- a/src/pages/OrganizationUsageTab.tsx
+++ b/src/pages/OrganizationUsageTab.tsx
@@ -1,10 +1,8 @@
 import { useMemo, useState, type ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
-import { Code, ConnectError } from '@connectrpc/connect';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQueries, useQuery } from '@tanstack/react-query';
-import { create } from '@bufbuild/protobuf';
-import { TimestampSchema, type Timestamp } from '@bufbuild/protobuf/wkt';
+import type { Timestamp } from '@bufbuild/protobuf/wkt';
 import {
   Bar,
   BarChart,
@@ -15,14 +13,13 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import { llmClient, meteringClient } from '@/api/client';
+import { llmClient } from '@/api/client';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   Granularity,
-  QueryUsageResponseSchema,
   Unit,
   type QueryUsageResponse,
   type UsageBucket,
@@ -30,6 +27,7 @@ import {
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useIdentityHandles } from '@/hooks/useIdentityHandles';
 import { formatDateOnly, formatTimestamp, timestampToMillis, truncate } from '@/lib/format';
+import { queryUsage } from '@/lib/metering';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
 import {
   formatUsageHours,
@@ -206,18 +204,7 @@ const llmKindLabels: Record<string, string> = {
   output: 'Output',
 };
 
-function toTimestamp(date: Date): Timestamp {
-  return create(TimestampSchema, {
-    seconds: BigInt(Math.floor(date.getTime() / 1000)),
-    nanos: 0,
-  });
-}
-
-function isUsageUnavailable(error: unknown): boolean {
-  return error instanceof ConnectError && (error.code === Code.Unimplemented || error.code === Code.NotFound);
-}
-
-async function queryUsageSafely({
+function queryUsageSafely({
   organizationId,
   start,
   end,
@@ -226,30 +213,22 @@ async function queryUsageSafely({
   timeZone,
 }: {
   organizationId: string;
-  start: Timestamp;
-  end: Timestamp;
+  start: Date;
+  end: Date;
   config: UsageQueryConfig;
   rangeGranularity: Granularity;
   timeZone: string;
 }): Promise<QueryUsageResponse> {
-  const granularity = config.useRangeGranularity ? rangeGranularity : config.granularity;
-  try {
-    return await meteringClient.queryUsage({
-      orgId: organizationId,
-      start,
-      end,
-      unit: config.unit,
-      labelFilters: config.labelFilters ?? {},
-      groupBy: config.groupBy ?? '',
-      granularity,
-      timeZone,
-    });
-  } catch (error) {
-    if (isUsageUnavailable(error)) {
-      return create(QueryUsageResponseSchema, { buckets: [] });
-    }
-    throw error;
-  }
+  return queryUsage({
+    organizationId,
+    start,
+    end,
+    unit: config.unit,
+    labelFilters: config.labelFilters,
+    groupBy: config.groupBy,
+    granularity: config.useRangeGranularity ? rangeGranularity : config.granularity,
+    timeZone,
+  });
 }
 
 function formatDateInput(date: Date): string {
@@ -579,21 +558,19 @@ export function OrganizationUsageTab() {
   );
   const timeZone = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, []);
 
-  const startTimestamp = range ? toTimestamp(range.start) : undefined;
-  const endTimestamp = range ? toTimestamp(range.end) : undefined;
   const isRangeReady = Boolean(range && organizationId);
 
   const usageQueries = useQueries({
     queries: usageQueryConfigs.map((config) => ({
       queryKey: ['metering', organizationId, rangeKey, rangeGranularity, timeZone, config.key],
       queryFn: () => {
-        if (!startTimestamp || !endTimestamp) {
+        if (!range) {
           throw new Error('Usage range not available.');
         }
         return queryUsageSafely({
           organizationId,
-          start: startTimestamp,
-          end: endTimestamp,
+          start: range.start,
+          end: range.end,
           config,
           rangeGranularity,
           timeZone,

--- a/src/pages/overview/OverviewActivity.tsx
+++ b/src/pages/overview/OverviewActivity.tsx
@@ -1,0 +1,189 @@
+import { useMemo, type ReactNode } from 'react';
+import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
+import { TrendingDownIcon, TrendingUpIcon } from 'lucide-react';
+import { ChartTooltip } from '@/components/ChartTooltip';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { timestampToMillis } from '@/lib/format';
+import { formatUsageCompact, formatUsageNumber, microsToHours, microsToNumber } from '@/lib/usage';
+import { ACTIVITY_WINDOW_DAYS, DAY_MS, useOverviewActivity } from './useOverviewActivity';
+
+type OverviewActivityProps = {
+  organizationId: string;
+  runnerCount: number;
+};
+
+const dayFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+
+/** Two points is a line with no context; three is the shortest chart worth drawing. */
+const MIN_CHART_DAYS = 3;
+
+/** Local calendar day, which is the grain metering buckets by. */
+function dayKey(date: Date): string {
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+}
+
+/** A headline reads better round: minutes matter under an hour, not over forty. */
+function formatHours(micros: bigint): string {
+  const hours = microsToHours(micros);
+  if (hours === 0) return '0h';
+  if (hours < 10) return `${hours.toFixed(1)}h`;
+  return `${Math.round(hours)}h`;
+}
+
+function Metric({
+  label,
+  value,
+  hint,
+  isPending,
+  testId,
+}: {
+  label: string;
+  value: string;
+  hint?: ReactNode;
+  isPending: boolean;
+  testId: string;
+}) {
+  return (
+    <Card className="gap-1 border-border px-4 py-3" data-testid={testId}>
+      <div className="text-xs text-muted-foreground">{label}</div>
+      {isPending ? (
+        <Skeleton className="h-7 w-20" />
+      ) : (
+        <div className="text-2xl font-semibold text-foreground">{value}</div>
+      )}
+      {!isPending && hint ? <div className="text-xs text-muted-foreground">{hint}</div> : null}
+    </Card>
+  );
+}
+
+export function OverviewActivity({ organizationId, runnerCount }: OverviewActivityProps) {
+  const activity = useOverviewActivity(organizationId);
+
+  // Metering answers only with the days that had usage. The rest are filled in,
+  // then the empty run before the first one is dropped: an organization two days
+  // old should not be shown five days of nothing it could not have used.
+  const series = useMemo(() => {
+    const byDay = new Map<string, number>();
+    activity.daily.forEach((bucket) => {
+      const millis = timestampToMillis(bucket.timestamp);
+      if (millis) byDay.set(dayKey(new Date(millis)), microsToNumber(bucket.value));
+    });
+
+    const days = Array.from({ length: ACTIVITY_WINDOW_DAYS }, (_, index) => {
+      const day = new Date(activity.end.getTime() - (ACTIVITY_WINDOW_DAYS - 1 - index) * DAY_MS);
+      return { label: dayFormatter.format(day), tokens: byDay.get(dayKey(day)) ?? 0 };
+    });
+
+    const first = days.findIndex((point) => point.tokens > 0);
+    if (first < 0) return days;
+    // Starts a day early so the shape has somewhere to rise from.
+    return days.slice(Math.min(Math.max(first - 1, 0), days.length - MIN_CHART_DAYS));
+  }, [activity.daily, activity.end]);
+
+  const hasSeries = series.some((point) => point.tokens > 0);
+  const edgeTicks = [series[0]?.label, series[series.length - 1]?.label].filter(Boolean);
+
+  // A missing metering service answers with no buckets rather than an error, so
+  // the same empty state covers both an idle organization and a deployment that
+  // does not meter at all.
+  const trend =
+    activity.tokens === 0n
+      ? null
+      : activity.previousTokens === 0n
+        ? { rising: true, label: 'nothing the week before' }
+        : {
+            rising: activity.tokens >= activity.previousTokens,
+            label: `vs ${formatUsageCompact(activity.previousTokens)} the week before`,
+          };
+  const TrendIcon = trend?.rising ? TrendingUpIcon : TrendingDownIcon;
+
+  return (
+    <div className="space-y-3" data-testid="organization-overview-activity">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Metric
+          label="Tokens"
+          value={formatUsageCompact(activity.tokens)}
+          isPending={activity.isPending}
+          hint={
+            trend ? (
+              <span className="flex items-center gap-1" data-testid="organization-overview-token-trend">
+                <TrendIcon className="h-3.5 w-3.5" />
+                {trend.label}
+              </span>
+            ) : null
+          }
+          testId="organization-overview-tokens"
+        />
+        <Metric
+          label="Compute"
+          value={formatHours(activity.compute)}
+          isPending={activity.isPending}
+          hint={runnerCount > 0 ? `across ${runnerCount} ${runnerCount === 1 ? 'runner' : 'runners'}` : null}
+          testId="organization-overview-compute"
+        />
+        <Metric
+          label="Threads"
+          value={formatUsageCompact(activity.threads)}
+          isPending={activity.isPending}
+          hint={`${formatUsageCompact(activity.messages)} messages`}
+          testId="organization-overview-threads"
+        />
+      </div>
+
+      <Card className="gap-3 border-border px-4 py-3" data-testid="organization-overview-token-chart">
+        <div className="flex items-baseline justify-between gap-3">
+          <span className="text-xs text-muted-foreground">Token use</span>
+          <span className="text-xs text-muted-foreground">
+            {hasSeries ? `Last ${series.length} days` : `Last ${ACTIVITY_WINDOW_DAYS} days`}
+          </span>
+        </div>
+        {activity.isPending ? (
+          <Skeleton className="h-24 w-full" />
+        ) : activity.isError ? (
+          <div className="py-6 text-sm text-muted-foreground">Failed to load usage.</div>
+        ) : !hasSeries ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            No model calls in the last {ACTIVITY_WINDOW_DAYS} days.
+          </div>
+        ) : (
+          // An area rather than bars: it spans the card whatever the number of
+          // days, where three bars in a week-wide chart read as three accidents.
+          <ResponsiveContainer width="100%" height={112}>
+            <AreaChart data={series} margin={{ top: 4, bottom: 0, left: 0, right: 0 }}>
+              <defs>
+                <linearGradient id="overview-tokens" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="var(--color-chart-1)" stopOpacity={0.35} />
+                  <stop offset="100%" stopColor="var(--color-chart-1)" stopOpacity={0.02} />
+                </linearGradient>
+              </defs>
+              {/* Only the ends are labelled: the shape carries the trend, the
+                  tooltip carries the numbers. */}
+              <XAxis
+                dataKey="label"
+                ticks={edgeTicks}
+                tick={{ fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                interval={0}
+              />
+              <Tooltip
+                cursor={{ stroke: 'var(--color-border)', strokeWidth: 1 }}
+                content={<ChartTooltip format={(value) => `${formatUsageNumber(value)} tokens`} />}
+              />
+              <Area
+                dataKey="tokens"
+                type="monotone"
+                stroke="var(--color-chart-1)"
+                strokeWidth={2}
+                fill="url(#overview-tokens)"
+                dot={false}
+                activeDot={{ r: 3, strokeWidth: 0 }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/overview/RecentThreads.tsx
+++ b/src/pages/overview/RecentThreads.tsx
@@ -1,0 +1,122 @@
+import { useMemo } from 'react';
+import { NavLink } from 'react-router-dom';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { threadsClient } from '@/api/client';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  ListOrganizationThreadsSortField,
+  MessageOrder,
+  SortDirection,
+} from '@/gen/agynio/api/threads/v1/threads_pb';
+import { formatAge, truncate } from '@/lib/format';
+
+type RecentThreadsProps = {
+  organizationId: string;
+};
+
+const MAX_ROWS = 5;
+const OPENER_LENGTH = 72;
+
+/** The line a thread opens with, on one line and short enough for a row. */
+function opener(body: string): string {
+  const collapsed = body.replace(/\s+/g, ' ').trim();
+  return collapsed ? truncate(collapsed, OPENER_LENGTH) : '';
+}
+
+export function RecentThreads({ organizationId }: RecentThreadsProps) {
+  const threadsQuery = useQuery({
+    queryKey: ['threads', organizationId, 'overview'],
+    queryFn: () =>
+      threadsClient.listOrganizationThreads({
+        organizationId,
+        pageSize: MAX_ROWS,
+        pageToken: '',
+        sort: { field: ListOrganizationThreadsSortField.UPDATED, direction: SortDirection.DESC },
+      }),
+    enabled: Boolean(organizationId),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+  const threads = useMemo(() => threadsQuery.data?.threads ?? [], [threadsQuery.data?.threads]);
+
+  // One call per row: the list carries no message bodies, and the opening line
+  // is what tells the conversations apart.
+  const openers = useQueries({
+    queries: threads.map((thread) => ({
+      queryKey: ['threads', thread.id, 'opener'],
+      queryFn: () =>
+        threadsClient.getMessages({
+          threadId: thread.id,
+          pageSize: 1,
+          pageToken: '',
+          order: MessageOrder.OLDEST_FIRST,
+        }),
+      enabled: Boolean(thread.id),
+      staleTime: 300_000,
+      refetchOnWindowFocus: false,
+      retry: false,
+    })),
+  });
+
+  // Listing an organization's threads is a permission a plain member may not
+  // hold, and a panel that only ever says "forbidden" is worse than no panel.
+  const isForbidden =
+    threadsQuery.error instanceof ConnectError && threadsQuery.error.code === Code.PermissionDenied;
+  if (isForbidden) return null;
+
+  return (
+    <Card className="gap-3 border-border px-4 py-3" data-testid="organization-overview-threads-panel">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-xs text-muted-foreground">Recent threads</span>
+        {threads.length > 0 ? (
+          <NavLink
+            to={`/organizations/${organizationId}/threads`}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            All threads
+          </NavLink>
+        ) : null}
+      </div>
+      <div>
+        {threadsQuery.isPending ? (
+          <div className="space-y-3">
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-2/3" />
+          </div>
+        ) : threadsQuery.isError ? (
+          <div className="text-sm text-muted-foreground">Failed to load threads.</div>
+        ) : threads.length === 0 ? (
+          <div className="py-6 text-sm text-muted-foreground">
+            No conversations yet. One starts when someone messages an agent.
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            {threads.map((thread, index) => {
+              const first = openers[index]?.data?.messages?.[0];
+              const label = first ? opener(first.body) : '';
+              return (
+                <NavLink
+                  key={thread.id}
+                  to={`/organizations/${organizationId}/threads/${thread.id}`}
+                  className="flex items-baseline gap-3 py-2 first:pt-0 last:pb-0 hover:text-foreground"
+                  data-testid="organization-overview-thread-row"
+                >
+                  <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                    {label || <span className="text-muted-foreground">No messages yet</span>}
+                  </span>
+                  <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                    {formatAge(thread.updatedAt ?? thread.createdAt)}
+                  </span>
+                </NavLink>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/pages/overview/RunningNow.tsx
+++ b/src/pages/overview/RunningNow.tsx
@@ -1,0 +1,83 @@
+import { NavLink } from 'react-router-dom';
+import { BotIcon, TerminalIcon } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { RuntimeOwnerKind, WorkloadStatus, type Workload } from '@/gen/agynio/api/runners/v1/runners_pb';
+import { formatAge } from '@/lib/format';
+
+type RunningNowProps = {
+  organizationId: string;
+  workloads: Workload[];
+  isPending: boolean;
+  isError: boolean;
+};
+
+const MAX_ROWS = 5;
+
+/** What the workload is, in the words of whatever owns it. */
+function workloadName(workload: Workload): string {
+  return workload.ownerName || workload.agentClassName || workload.agentName || workload.meta?.id || 'Workload';
+}
+
+export function RunningNow({ organizationId, workloads, isPending, isError }: RunningNowProps) {
+  const rows = workloads.slice(0, MAX_ROWS);
+
+  return (
+    <Card className="gap-3 border-border px-4 py-3" data-testid="organization-overview-running">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-xs text-muted-foreground">Running now</span>
+        {workloads.length > rows.length ? (
+          <NavLink
+            to={`/organizations/${organizationId}/workloads`}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            {workloads.length} total
+          </NavLink>
+        ) : null}
+      </div>
+      <div>
+        {isPending ? (
+          <div className="space-y-3">
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-2/3" />
+          </div>
+        ) : isError ? (
+          <div className="text-sm text-muted-foreground">Failed to load workloads.</div>
+        ) : rows.length === 0 ? (
+          <div className="py-6 text-sm text-muted-foreground">
+            Nothing is running. Workloads start when an agent is spoken to.
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            {rows.map((workload) => {
+              const Icon = workload.ownerKind === RuntimeOwnerKind.SANDBOX ? TerminalIcon : BotIcon;
+              return (
+                <NavLink
+                  key={workload.meta?.id}
+                  to={`/organizations/${organizationId}/workloads/${workload.meta?.id}`}
+                  className="flex items-center gap-3 py-2 first:pt-0 last:pb-0 hover:text-foreground"
+                  data-testid="organization-overview-running-row"
+                >
+                  <span
+                    className={
+                      workload.status === WorkloadStatus.RUNNING
+                        ? 'h-2 w-2 shrink-0 rounded-full bg-primary'
+                        : 'h-2 w-2 shrink-0 animate-pulse rounded-full bg-muted-foreground'
+                    }
+                  />
+                  <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                    {workloadName(workload)}
+                  </span>
+                  <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                    {formatAge(workload.meta?.createdAt)}
+                  </span>
+                </NavLink>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/pages/overview/useOverviewActivity.ts
+++ b/src/pages/overview/useOverviewActivity.ts
@@ -1,0 +1,118 @@
+import { useMemo } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import { Granularity, Unit, type UsageBucket } from '@/gen/agynio/api/metering/v1/metering_pb';
+import { queryUsage, sumUsageBuckets } from '@/lib/metering';
+
+export const DAY_MS = 86_400_000;
+export const ACTIVITY_WINDOW_DAYS = 7;
+
+export type ActivityUsage = {
+  /** Tokens over the window, and over the window before it, for the comparison. */
+  tokens: bigint;
+  previousTokens: bigint;
+  /** Flavor-seconds, in micros, as metering reports them. */
+  compute: bigint;
+  threads: bigint;
+  messages: bigint;
+  /** Only days with usage come back, so the chart fills the rest itself. */
+  daily: UsageBucket[];
+  end: Date;
+  isPending: boolean;
+  isError: boolean;
+};
+
+type ActivityQuery = {
+  key: string;
+  unit: Unit;
+  granularity: Granularity;
+  start: Date;
+  end?: Date;
+  labelFilters?: Record<string, string>;
+};
+
+/**
+ * The window both the figures and the chart are read over. Rounded down to the
+ * minute so a remount reuses the cached answer rather than asking again for a
+ * range that moved by a second.
+ */
+function activityRange(): { start: Date; end: Date; previousStart: Date } {
+  const end = new Date();
+  end.setSeconds(0, 0);
+  return {
+    end,
+    start: new Date(end.getTime() - ACTIVITY_WINDOW_DAYS * DAY_MS),
+    previousStart: new Date(end.getTime() - 2 * ACTIVITY_WINDOW_DAYS * DAY_MS),
+  };
+}
+
+/**
+ * Token queries carry no resource filter on purpose. The usage tab excludes
+ * subscription tokens because they are a flat fee and summing them produces a
+ * bill that does not exist -- but this is a readout of what the organization
+ * did, and a subscription's tokens are tokens it spent.
+ */
+export function useOverviewActivity(organizationId: string): ActivityUsage {
+  const range = useMemo(activityRange, [organizationId]);
+
+  const configs = useMemo<ActivityQuery[]>(
+    () => [
+      { key: 'tokens', unit: Unit.TOKENS, granularity: Granularity.TOTAL, start: range.start },
+      {
+        key: 'tokens-previous',
+        unit: Unit.TOKENS,
+        granularity: Granularity.TOTAL,
+        start: range.previousStart,
+        end: range.start,
+      },
+      { key: 'tokens-daily', unit: Unit.TOKENS, granularity: Granularity.DAY, start: range.start },
+      { key: 'compute', unit: Unit.FLAVOR_SECONDS, granularity: Granularity.TOTAL, start: range.start },
+      {
+        key: 'threads',
+        unit: Unit.COUNT,
+        granularity: Granularity.TOTAL,
+        start: range.start,
+        labelFilters: { kind: 'thread' },
+      },
+      {
+        key: 'messages',
+        unit: Unit.COUNT,
+        granularity: Granularity.TOTAL,
+        start: range.start,
+        labelFilters: { kind: 'message' },
+      },
+    ],
+    [range],
+  );
+
+  const results = useQueries({
+    queries: configs.map((config) => ({
+      queryKey: ['metering', organizationId, 'overview', config.key, range.end.getTime()],
+      queryFn: () =>
+        queryUsage({
+          organizationId,
+          start: config.start,
+          end: config.end ?? range.end,
+          unit: config.unit,
+          granularity: config.granularity,
+          labelFilters: config.labelFilters,
+        }),
+      enabled: Boolean(organizationId),
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const [tokens, previousTokens, daily, compute, threads, messages] = results;
+
+  return {
+    tokens: sumUsageBuckets(tokens.data?.buckets ?? []),
+    previousTokens: sumUsageBuckets(previousTokens.data?.buckets ?? []),
+    compute: sumUsageBuckets(compute.data?.buckets ?? []),
+    threads: sumUsageBuckets(threads.data?.buckets ?? []),
+    messages: sumUsageBuckets(messages.data?.buckets ?? []),
+    daily: daily.data?.buckets ?? [],
+    end: range.end,
+    isPending: results.some((result) => result.isPending),
+    isError: results.some((result) => result.isError),
+  };
+}


### PR DESCRIPTION
The page was seven counters and an ID. Six of them were small integers that
change once a month, and none of them answered the question someone opens an
organization to ask: is anything happening in it. The data to answer that was
already being fetched -- the workloads query ran, and its result was reduced to
a length.

So the counters keep their links and lose the page. Above them: tokens, compute
hours and threads over the last week, a chart of daily token use, what is
running right now by name and uptime, and the conversations people are actually
having, each shown by the line it opens with.

Token figures carry no resource filter. The usage tab excludes subscription
tokens from spend views because a flat fee has no marginal cost, but this is a
readout of what an organization did, not what it owes -- filtering the same way
would report zero for exactly the native-mode organizations the setup wizard
creates. The request counter there already reasons this way.

The chart shows the days the organization could have used, not a fixed seven:
metering answers only with the days that had usage, so an organization two days
old was drawing two bars against five days of nothing it was never around for.
The empty run before the first busy day is dropped, one day of lead-in is kept
so the shape rises from zero, and the header says how many days it is showing.

Charts get a themed tooltip. Recharts styles its own inline -- white box, grey
border, series-coloured text -- so it ignores the theme and would be unreadable
in dark mode. The usage tab still uses the built-in one; adopting this there
needs stacked series and label formatters it does not handle yet.

Metering moves to a lib. Whether an absent metering service is an error or an
empty series is a rule, and it was about to exist in two places.