### PR TITLE
Pick a vendor when adding an LLM provider

### DIFF
--- a/src/__tests__/llm-provider-dialog.test.tsx
+++ b/src/__tests__/llm-provider-dialog.test.tsx
@@ -1,0 +1,134 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PageTitleProvider } from '@/context/PageTitleContext';
+import { AuthMethod, Protocol } from '@/gen/agynio/api/llm/v1/llm_pb';
+import { OrganizationLlmProvidersTab } from '@/pages/OrganizationLlmProvidersTab';
+
+const { listLLMProviders, createLLMProvider } = vi.hoisted(() => ({
+  listLLMProviders: vi.fn(),
+  createLLMProvider: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  llmClient: {
+    listLLMProviders,
+    createLLMProvider,
+    updateLLMProvider: vi.fn(),
+    deleteLLMProvider: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function renderTab() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <PageTitleProvider>
+        <MemoryRouter initialEntries={['/organizations/org-1/llm-providers']}>
+          <Routes>
+            <Route path="/organizations/:id/llm-providers" element={<OrganizationLlmProvidersTab />} />
+          </Routes>
+        </MemoryRouter>
+      </PageTitleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+async function openCreateDialog() {
+  listLLMProviders.mockResolvedValue({ providers: [], nextPageToken: '' });
+  renderTab();
+  fireEvent.click(await screen.findByTestId('organization-llm-providers-create'));
+  await screen.findByTestId('organization-llm-providers-create-dialog');
+}
+
+describe('add provider dialog', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('opens on the default vendor', async () => {
+    await openCreateDialog();
+    expect(
+      screen.getByTestId('organization-llm-providers-create-preset-openai').getAttribute('aria-checked'),
+    ).toBe('true');
+    expect(
+      screen.getByTestId('organization-llm-providers-create-preset-custom').getAttribute('aria-checked'),
+    ).toBe('false');
+  });
+
+  // The endpoint, auth method and protocol are the vendor's, not a choice, so
+  // for a known vendor there is nothing to ask beyond the key.
+  it('asks only for the key when a vendor is chosen', async () => {
+    await openCreateDialog();
+
+    expect(screen.queryByTestId('organization-llm-providers-create-endpoint')).toBeNull();
+    expect(screen.queryByTestId('organization-llm-providers-create-auth')).toBeNull();
+    expect(screen.queryByTestId('organization-llm-providers-create-protocol')).toBeNull();
+    expect(screen.getByTestId('organization-llm-providers-create-token')).not.toBeNull();
+  });
+
+  it('reveals the fields only for a custom endpoint', async () => {
+    await openCreateDialog();
+
+    fireEvent.click(screen.getByTestId('organization-llm-providers-create-preset-custom'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('organization-llm-providers-create-endpoint')).not.toBeNull();
+    });
+    expect(screen.getByTestId('organization-llm-providers-create-auth')).not.toBeNull();
+    expect(screen.getByTestId('organization-llm-providers-create-protocol')).not.toBeNull();
+    // Custom starts blank rather than inheriting the vendor's URL.
+    expect((screen.getByTestId('organization-llm-providers-create-endpoint') as HTMLInputElement).value).toBe('');
+
+    fireEvent.click(screen.getByTestId('organization-llm-providers-create-preset-anthropic'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('organization-llm-providers-create-endpoint')).toBeNull();
+    });
+  });
+
+  // The whole point of the preset: a vendor the user never configured still
+  // gets the endpoint, header and protocol that vendor actually needs.
+  it('sends the vendor endpoint, auth method and protocol it never showed', async () => {
+    createLLMProvider.mockResolvedValue({});
+    await openCreateDialog();
+
+    fireEvent.click(screen.getByTestId('organization-llm-providers-create-preset-anthropic'));
+    fireEvent.change(screen.getByTestId('organization-llm-providers-create-token'), {
+      target: { value: 'sk-ant-secret' },
+    });
+    fireEvent.click(screen.getByTestId('organization-llm-providers-create-submit'));
+
+    await waitFor(() => {
+      expect(createLLMProvider).toHaveBeenCalledWith({
+        endpoint: 'https://api.anthropic.com/v1/messages',
+        authMethod: AuthMethod.X_API_KEY,
+        protocol: Protocol.ANTHROPIC_MESSAGES,
+        token: 'sk-ant-secret',
+        organizationId: 'org-1',
+      });
+    });
+  });
+
+  it('defaults a straight submit to the vendor it opened on', async () => {
+    createLLMProvider.mockResolvedValue({});
+    await openCreateDialog();
+
+    fireEvent.change(screen.getByTestId('organization-llm-providers-create-token'), {
+      target: { value: 'sk-secret' },
+    });
+    fireEvent.click(screen.getByTestId('organization-llm-providers-create-submit'));
+
+    await waitFor(() => {
+      expect(createLLMProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: 'https://api.openai.com/v1/responses',
+          authMethod: AuthMethod.BEARER,
+          protocol: Protocol.RESPONSES,
+        }),
+      );
+    });
+  });
+});

--- a/src/__tests__/llm-provider-presets.test.ts
+++ b/src/__tests__/llm-provider-presets.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { AuthMethod, Protocol } from '@/gen/agynio/api/llm/v1/llm_pb';
+import { formatAuthMethod } from '@/lib/format';
+import { LLM_PROVIDER_PRESETS, formatLlmProtocol } from '@/lib/llmProviders';
+
+const openai = LLM_PROVIDER_PRESETS.find((preset) => preset.key === 'openai')!;
+const anthropic = LLM_PROVIDER_PRESETS.find((preset) => preset.key === 'anthropic')!;
+
+describe('llm provider presets', () => {
+  // The endpoint is the URL the proxy POSTs to, not an origin it appends a path
+  // to, so a preset missing the path sends every call to the wrong place.
+  it('carries the full endpoint each vendor answers on', () => {
+    expect(openai.endpoint).toBe('https://api.openai.com/v1/responses');
+    expect(anthropic.endpoint).toBe('https://api.anthropic.com/v1/messages');
+  });
+
+  // Auth method and protocol are the vendor's, not a preference. Anthropic
+  // reads x-api-key and speaks Messages; a bearer token there is a 401.
+  // The picker shows these under each name in place of the fields they fix, so
+  // a preset without them leaves the tile blank.
+  it('says what each vendor speaks and what its credential looks like', () => {
+    expect(openai.hint).toBeTruthy();
+    expect(openai.tokenPlaceholder).toBeTruthy();
+    expect(anthropic.hint).toBeTruthy();
+    expect(anthropic.tokenPlaceholder).toBeTruthy();
+  });
+
+  // OpenAI is the tile selected when the dialog opens, so it has to be first.
+  it('leads with the default vendor', () => {
+    expect(LLM_PROVIDER_PRESETS[0].key).toBe('openai');
+  });
+
+  it('pairs each vendor with the auth method and protocol it actually uses', () => {
+    expect(openai.authMethod).toBe(AuthMethod.BEARER);
+    expect(openai.protocol).toBe(Protocol.RESPONSES);
+    expect(anthropic.authMethod).toBe(AuthMethod.X_API_KEY);
+    expect(anthropic.protocol).toBe(Protocol.ANTHROPIC_MESSAGES);
+  });
+
+});
+
+describe('llm provider labels', () => {
+  it('names both protocols', () => {
+    expect(formatLlmProtocol(Protocol.RESPONSES)).toBe('Responses');
+    expect(formatLlmProtocol(Protocol.ANTHROPIC_MESSAGES)).toBe('Anthropic Messages');
+    expect(formatLlmProtocol(Protocol.UNSPECIFIED)).toBe('Unspecified');
+  });
+
+  // Every Anthropic provider listed as "Unspecified" until this was mapped.
+  it('names x-api-key rather than calling it unspecified', () => {
+    expect(formatAuthMethod(AuthMethod.X_API_KEY)).toBe('x-api-key');
+    expect(formatAuthMethod(AuthMethod.BEARER)).toBe('Bearer');
+    expect(formatAuthMethod(AuthMethod.UNSPECIFIED)).toBe('Unspecified');
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -225,7 +225,9 @@ export function formatClusterRole(role?: ClusterRole): string {
 
 export function formatAuthMethod(method?: AuthMethod): string {
   if (method === AuthMethod.BEARER) return 'Bearer';
-  if (method === AuthMethod.UNSPECIFIED) return 'Unspecified';
+  // Anthropic providers authenticate this way, so leaving it out of the map
+  // listed every one of them as "Unspecified".
+  if (method === AuthMethod.X_API_KEY) return 'x-api-key';
   return 'Unspecified';
 }
 

--- a/src/lib/llmProviders.ts
+++ b/src/lib/llmProviders.ts
@@ -1,0 +1,49 @@
+import { AuthMethod, Protocol } from '@/gen/agynio/api/llm/v1/llm_pb';
+
+export function formatLlmProtocol(protocol?: Protocol): string {
+  if (protocol === Protocol.RESPONSES) return 'Responses';
+  if (protocol === Protocol.ANTHROPIC_MESSAGES) return 'Anthropic Messages';
+  return 'Unspecified';
+}
+
+export type LlmProviderPresetKey = 'openai' | 'anthropic' | 'custom';
+
+export type LlmProviderPreset = {
+  key: LlmProviderPresetKey;
+  label: string;
+  /** What the vendor's endpoint speaks, shown in place of the fields it fixes. */
+  hint: string;
+  /** Shape of the credential, so the field says what to paste into it. */
+  tokenPlaceholder: string;
+  endpoint: string;
+  authMethod: AuthMethod;
+  protocol: Protocol;
+};
+
+/**
+ * The endpoint is the URL the proxy POSTs to, not an origin it appends a path
+ * to, so these carry the full path each vendor answers on. Auth method and
+ * protocol are the vendor's, not a preference: Anthropic reads x-api-key and
+ * speaks Messages, OpenAI reads a bearer token and speaks Responses.
+ */
+export const LLM_PROVIDER_PRESETS: LlmProviderPreset[] = [
+  {
+    key: 'openai',
+    label: 'OpenAI',
+    hint: 'Responses API',
+    tokenPlaceholder: 'sk-...',
+    endpoint: 'https://api.openai.com/v1/responses',
+    authMethod: AuthMethod.BEARER,
+    protocol: Protocol.RESPONSES,
+  },
+  {
+    key: 'anthropic',
+    label: 'Anthropic',
+    hint: 'Messages API',
+    tokenPlaceholder: 'sk-ant-...',
+    endpoint: 'https://api.anthropic.com/v1/messages',
+    authMethod: AuthMethod.X_API_KEY,
+    protocol: Protocol.ANTHROPIC_MESSAGES,
+  },
+];
+

--- a/src/pages/OrganizationLlmProvidersTab.tsx
+++ b/src/pages/OrganizationLlmProvidersTab.tsx
@@ -19,12 +19,66 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { AuthMethod, type LLMProvider } from '@/gen/agynio/api/llm/v1/llm_pb';
+import { AuthMethod, Protocol, type LLMProvider } from '@/gen/agynio/api/llm/v1/llm_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useListControls } from '@/hooks/useListControls';
 import { formatAuthMethod, formatDateOnly, timestampToMillis } from '@/lib/format';
+import {
+  LLM_PROVIDER_PRESETS,
+  formatLlmProtocol,
+  type LlmProviderPresetKey,
+} from '@/lib/llmProviders';
+import { cn } from '@/lib/utils';
 import { DEFAULT_PAGE_SIZE } from '@/lib/pagination';
 import { toast } from 'sonner';
+
+const DEFAULT_PRESET = LLM_PROVIDER_PRESETS[0];
+
+/**
+ * A vendor is one of a handful of known things, so it gets tiles rather than a
+ * dropdown: every option is visible at once and reachable in one click, and
+ * each can carry what it implies about the endpoint underneath its name.
+ */
+function ProviderPresetPicker({
+  value,
+  onChange,
+}: {
+  value: LlmProviderPresetKey;
+  onChange: (key: LlmProviderPresetKey) => void;
+}) {
+  const options: Array<{ key: LlmProviderPresetKey; label: string; hint: string }> = [
+    ...LLM_PROVIDER_PRESETS.map((preset) => ({ key: preset.key, label: preset.label, hint: preset.hint })),
+    { key: 'custom', label: 'Custom', hint: 'Your own endpoint' },
+  ];
+
+  return (
+    <div role="radiogroup" aria-label="Provider" className="grid grid-cols-3 gap-2">
+      {options.map((option) => {
+        const selected = option.key === value;
+        return (
+          <button
+            key={option.key}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(option.key)}
+            className={cn(
+              'flex flex-col items-start gap-0.5 rounded-lg border px-3 py-2.5 text-left transition-colors',
+              'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring',
+              selected
+                ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                : 'border-border hover:bg-accent hover:text-accent-foreground',
+            )}
+            data-testid={`organization-llm-providers-create-preset-${option.key}`}
+          >
+            <span className="text-sm font-medium text-foreground">{option.label}</span>
+            <span className="text-xs text-muted-foreground">{option.hint}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 export function OrganizationLlmProvidersTab() {
   useDocumentTitle('LLM Providers');
@@ -33,8 +87,10 @@ export function OrganizationLlmProvidersTab() {
   const organizationId = id ?? '';
   const queryClient = useQueryClient();
   const [createOpen, setCreateOpen] = useState(false);
-  const [createEndpoint, setCreateEndpoint] = useState('');
-  const [createAuthMethod, setCreateAuthMethod] = useState<AuthMethod>(AuthMethod.BEARER);
+  const [createPreset, setCreatePreset] = useState<LlmProviderPresetKey>(DEFAULT_PRESET.key);
+  const [createEndpoint, setCreateEndpoint] = useState(DEFAULT_PRESET.endpoint);
+  const [createAuthMethod, setCreateAuthMethod] = useState<AuthMethod>(DEFAULT_PRESET.authMethod);
+  const [createProtocol, setCreateProtocol] = useState<Protocol>(DEFAULT_PRESET.protocol);
   const [createToken, setCreateToken] = useState('');
   const [createEndpointError, setCreateEndpointError] = useState('');
   const [createTokenError, setCreateTokenError] = useState('');
@@ -42,6 +98,7 @@ export function OrganizationLlmProvidersTab() {
   const [editProviderId, setEditProviderId] = useState<string | null>(null);
   const [editEndpoint, setEditEndpoint] = useState('');
   const [editAuthMethod, setEditAuthMethod] = useState<AuthMethod>(AuthMethod.BEARER);
+  const [editProtocol, setEditProtocol] = useState<Protocol>(Protocol.RESPONSES);
   const [editToken, setEditToken] = useState('');
   const [editEndpointError, setEditEndpointError] = useState('');
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
@@ -58,17 +115,18 @@ export function OrganizationLlmProvidersTab() {
   });
 
   const createProviderMutation = useMutation({
-    mutationFn: (payload: { endpoint: string; authMethod: AuthMethod; token: string; organizationId: string }) =>
-      llmClient.createLLMProvider(payload),
+    mutationFn: (payload: {
+      endpoint: string;
+      authMethod: AuthMethod;
+      protocol: Protocol;
+      token: string;
+      organizationId: string;
+    }) => llmClient.createLLMProvider(payload),
     onSuccess: () => {
       toast.success('LLM provider created.');
       void queryClient.invalidateQueries({ queryKey: ['llm', organizationId, 'providers'] });
       setCreateOpen(false);
-      setCreateEndpoint('');
-      setCreateAuthMethod(AuthMethod.BEARER);
-      setCreateToken('');
-      setCreateEndpointError('');
-      setCreateTokenError('');
+      resetCreateFields();
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : 'Failed to create LLM provider.');
@@ -76,8 +134,13 @@ export function OrganizationLlmProvidersTab() {
   });
 
   const updateProviderMutation = useMutation({
-    mutationFn: (payload: { id: string; endpoint?: string; authMethod?: AuthMethod; token?: string }) =>
-      llmClient.updateLLMProvider(payload),
+    mutationFn: (payload: {
+      id: string;
+      endpoint?: string;
+      authMethod?: AuthMethod;
+      protocol?: Protocol;
+      token?: string;
+    }) => llmClient.updateLLMProvider(payload),
     onSuccess: () => {
       toast.success('LLM provider updated.');
       void queryClient.invalidateQueries({ queryKey: ['llm', organizationId, 'providers'] });
@@ -101,6 +164,32 @@ export function OrganizationLlmProvidersTab() {
       toast.error(error instanceof Error ? error.message : 'Failed to delete LLM provider.');
     },
   });
+
+  const resetCreateFields = () => {
+    setCreatePreset(DEFAULT_PRESET.key);
+    setCreateEndpoint(DEFAULT_PRESET.endpoint);
+    setCreateAuthMethod(DEFAULT_PRESET.authMethod);
+    setCreateProtocol(DEFAULT_PRESET.protocol);
+    setCreateToken('');
+    setCreateEndpointError('');
+    setCreateTokenError('');
+  };
+
+  // A preset fixes the endpoint, the auth method and the protocol together --
+  // they are the vendor's, not a preference -- so choosing one sets all three
+  // and the fields come off screen. Custom clears the endpoint to be typed.
+  const handleCreatePresetChange = (key: LlmProviderPresetKey) => {
+    setCreatePreset(key);
+    const preset = LLM_PROVIDER_PRESETS.find((entry) => entry.key === key);
+    if (preset) {
+      setCreateEndpoint(preset.endpoint);
+      setCreateAuthMethod(preset.authMethod);
+      setCreateProtocol(preset.protocol);
+    } else {
+      setCreateEndpoint('');
+    }
+    setCreateEndpointError('');
+  };
 
   const isEndpointValid = (value: string) => value.startsWith('http://') || value.startsWith('https://');
 
@@ -131,6 +220,7 @@ export function OrganizationLlmProvidersTab() {
     createProviderMutation.mutate({
       endpoint: trimmedEndpoint,
       authMethod: createAuthMethod,
+      protocol: createProtocol,
       token: trimmedToken,
       organizationId,
     });
@@ -139,11 +229,7 @@ export function OrganizationLlmProvidersTab() {
   const handleCreateOpenChange = (open: boolean) => {
     setCreateOpen(open);
     if (!open) {
-      setCreateEndpoint('');
-      setCreateAuthMethod(AuthMethod.BEARER);
-      setCreateToken('');
-      setCreateEndpointError('');
-      setCreateTokenError('');
+      resetCreateFields();
     }
   };
 
@@ -156,6 +242,7 @@ export function OrganizationLlmProvidersTab() {
     setEditProviderId(providerId);
     setEditEndpoint(provider.endpoint);
     setEditAuthMethod(provider.authMethod || AuthMethod.BEARER);
+    setEditProtocol(provider.protocol || Protocol.RESPONSES);
     setEditToken('');
     setEditEndpointError('');
     setEditOpen(true);
@@ -180,6 +267,7 @@ export function OrganizationLlmProvidersTab() {
       id: editProviderId,
       endpoint: trimmedEndpoint,
       authMethod: editAuthMethod,
+      protocol: editProtocol,
       ...(trimmedToken ? { token: trimmedToken } : {}),
     });
   };
@@ -190,6 +278,7 @@ export function OrganizationLlmProvidersTab() {
       setEditProviderId(null);
       setEditEndpoint('');
       setEditAuthMethod(AuthMethod.BEARER);
+      setEditProtocol(Protocol.RESPONSES);
       setEditToken('');
       setEditEndpointError('');
     }
@@ -211,11 +300,13 @@ export function OrganizationLlmProvidersTab() {
       (provider) => provider.endpoint,
       (provider) => provider.meta?.id ?? '',
       (provider) => formatAuthMethod(provider.authMethod),
+      (provider) => formatLlmProtocol(provider.protocol),
       (provider) => formatDateOnly(provider.meta?.createdAt),
     ],
     sortOptions: {
       endpoint: (provider) => provider.endpoint,
       authMethod: (provider) => formatAuthMethod(provider.authMethod),
+      protocol: (provider) => formatLlmProtocol(provider.protocol),
       created: (provider) => timestampToMillis(provider.meta?.createdAt),
     },
     defaultSortKey: 'endpoint',
@@ -257,7 +348,7 @@ export function OrganizationLlmProvidersTab() {
         <Card className="border-border" data-testid="organization-llm-providers-table">
           <CardContent className="px-0">
             <div
-              className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_1fr_1fr_140px]"
+              className="grid gap-2 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid-cols-[2fr_1fr_1fr_1fr_140px]"
               data-testid="organization-llm-providers-header"
             >
               <SortableHeader
@@ -270,6 +361,13 @@ export function OrganizationLlmProvidersTab() {
               <SortableHeader
                 label="Auth Method"
                 sortKey="authMethod"
+                activeSortKey={listControls.sortKey}
+                sortDirection={listControls.sortDirection}
+                onSort={listControls.handleSort}
+              />
+              <SortableHeader
+                label="Protocol"
+                sortKey="protocol"
                 activeSortKey={listControls.sortKey}
                 sortDirection={listControls.sortDirection}
                 onSort={listControls.handleSort}
@@ -292,7 +390,7 @@ export function OrganizationLlmProvidersTab() {
                 visibleProviders.map((provider) => (
                   <div
                     key={provider.meta?.id ?? provider.endpoint}
-                    className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_1fr_140px]"
+                    className="grid items-center gap-2 px-6 py-4 text-sm text-foreground md:grid-cols-[2fr_1fr_1fr_1fr_140px]"
                     data-testid="organization-llm-provider-row"
                   >
                     <div>
@@ -305,6 +403,9 @@ export function OrganizationLlmProvidersTab() {
                     </div>
                     <span className="text-xs text-muted-foreground" data-testid="organization-llm-provider-auth">
                       {formatAuthMethod(provider.authMethod)}
+                    </span>
+                    <span className="text-xs text-muted-foreground" data-testid="organization-llm-provider-protocol">
+                      {formatLlmProtocol(provider.protocol)}
                     </span>
                     <span className="text-xs text-muted-foreground" data-testid="organization-llm-provider-created">
                       {formatDateOnly(provider.meta?.createdAt)}
@@ -351,43 +452,81 @@ export function OrganizationLlmProvidersTab() {
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="organization-llm-providers-create-endpoint">Endpoint URL</Label>
-              <Input
-                id="organization-llm-providers-create-endpoint"
-                placeholder="https://api.example.com"
-                value={createEndpoint}
-                onChange={(event) => {
-                  setCreateEndpoint(event.target.value);
-                  if (createEndpointError) setCreateEndpointError('');
-                }}
-                data-testid="organization-llm-providers-create-endpoint"
-              />
-              {createEndpointError ? <p className="text-sm text-destructive">{createEndpointError}</p> : null}
+              <Label>Provider</Label>
+              <ProviderPresetPicker value={createPreset} onChange={handleCreatePresetChange} />
             </div>
+            {createPreset === 'custom' ? (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="organization-llm-providers-create-endpoint">Endpoint URL</Label>
+                  <Input
+                    id="organization-llm-providers-create-endpoint"
+                    placeholder="https://api.example.com/v1/responses"
+                    value={createEndpoint}
+                    onChange={(event) => {
+                      setCreateEndpoint(event.target.value);
+                      if (createEndpointError) setCreateEndpointError('');
+                    }}
+                    data-testid="organization-llm-providers-create-endpoint"
+                  />
+                  {createEndpointError ? <p className="text-sm text-destructive">{createEndpointError}</p> : null}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="organization-llm-providers-create-auth">Auth Method</Label>
+                  <Select
+                    value={createAuthMethod === AuthMethod.X_API_KEY ? 'x-api-key' : 'bearer'}
+                    onValueChange={(value) =>
+                      setCreateAuthMethod(value === 'x-api-key' ? AuthMethod.X_API_KEY : AuthMethod.BEARER)
+                    }
+                  >
+                    <SelectTrigger
+                      id="organization-llm-providers-create-auth"
+                      data-testid="organization-llm-providers-create-auth"
+                    >
+                      <SelectValue placeholder="Select auth method" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="bearer">Bearer</SelectItem>
+                      <SelectItem value="x-api-key">x-api-key</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="organization-llm-providers-create-protocol">Protocol</Label>
+                  <Select
+                    value={createProtocol === Protocol.ANTHROPIC_MESSAGES ? 'anthropic-messages' : 'responses'}
+                    onValueChange={(value) =>
+                      setCreateProtocol(
+                        value === 'anthropic-messages' ? Protocol.ANTHROPIC_MESSAGES : Protocol.RESPONSES,
+                      )
+                    }
+                  >
+                    <SelectTrigger
+                      id="organization-llm-providers-create-protocol"
+                      data-testid="organization-llm-providers-create-protocol"
+                    >
+                      <SelectValue placeholder="Select protocol" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="responses">Responses</SelectItem>
+                      <SelectItem value="anthropic-messages">Anthropic Messages</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    The request shape the endpoint answers. The proxy reads usage out of the response with it, so a
+                    mismatch bills nothing.
+                  </p>
+                </div>
+              </>
+            ) : null}
             <div className="space-y-2">
-              <Label htmlFor="organization-llm-providers-create-auth">Auth Method</Label>
-              <Select
-                value={createAuthMethod === AuthMethod.BEARER ? 'bearer' : 'unspecified'}
-                onValueChange={(value) =>
-                  setCreateAuthMethod(value === 'bearer' ? AuthMethod.BEARER : AuthMethod.UNSPECIFIED)
-                }
-              >
-                <SelectTrigger
-                  id="organization-llm-providers-create-auth"
-                  data-testid="organization-llm-providers-create-auth"
-                >
-                  <SelectValue placeholder="Select auth method" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="bearer">Bearer</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="organization-llm-providers-create-token">Token</Label>
+              <Label htmlFor="organization-llm-providers-create-token">
+                {createPreset === 'custom' ? 'Token' : 'API key'}
+              </Label>
               <Input
                 id="organization-llm-providers-create-token"
                 type="password"
+                placeholder={LLM_PROVIDER_PRESETS.find((preset) => preset.key === createPreset)?.tokenPlaceholder}
                 value={createToken}
                 onChange={(event) => {
                   setCreateToken(event.target.value);
@@ -440,9 +579,9 @@ export function OrganizationLlmProvidersTab() {
             <div className="space-y-2">
               <Label htmlFor="organization-llm-providers-edit-auth">Auth Method</Label>
               <Select
-                value={editAuthMethod === AuthMethod.BEARER ? 'bearer' : 'unspecified'}
+                value={editAuthMethod === AuthMethod.X_API_KEY ? 'x-api-key' : 'bearer'}
                 onValueChange={(value) =>
-                  setEditAuthMethod(value === 'bearer' ? AuthMethod.BEARER : AuthMethod.UNSPECIFIED)
+                  setEditAuthMethod(value === 'x-api-key' ? AuthMethod.X_API_KEY : AuthMethod.BEARER)
                 }
               >
                 <SelectTrigger
@@ -453,8 +592,33 @@ export function OrganizationLlmProvidersTab() {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="bearer">Bearer</SelectItem>
+                  <SelectItem value="x-api-key">x-api-key</SelectItem>
                 </SelectContent>
               </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="organization-llm-providers-edit-protocol">Protocol</Label>
+              <Select
+                value={editProtocol === Protocol.ANTHROPIC_MESSAGES ? 'anthropic-messages' : 'responses'}
+                onValueChange={(value) =>
+                  setEditProtocol(value === 'anthropic-messages' ? Protocol.ANTHROPIC_MESSAGES : Protocol.RESPONSES)
+                }
+              >
+                <SelectTrigger
+                  id="organization-llm-providers-edit-protocol"
+                  data-testid="organization-llm-providers-edit-protocol"
+                >
+                  <SelectValue placeholder="Select protocol" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="responses">Responses</SelectItem>
+                  <SelectItem value="anthropic-messages">Anthropic Messages</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                The request shape the endpoint answers. The proxy reads usage out of the response with it, so a
+                mismatch bills nothing.
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="organization-llm-providers-edit-token">Token</Label>


### PR DESCRIPTION
### An Anthropic provider could not be registered from this dialog

There was no protocol control, so the console sent none — and the service reads an unset protocol on create as Responses ([`allowUnspecified = true`](https://github.com/agynio/llm/blob/main/internal/grpcserver/server.go)). There was no way to select `x-api-key` either, so the credential would have gone out as a bearer token. Together: the endpoint answers 404 or 401, and the proxy tries to read usage out of a reply shape it never received.

### Vendor first

The endpoint, the auth method and the protocol are the vendor's, not a preference, so for a known vendor the dialog no longer asks for them:

| | |
|---|---|
| **OpenAI** | `https://api.openai.com/v1/responses` · Bearer · Responses |
| **Anthropic** | `https://api.anthropic.com/v1/messages` · x-api-key · Anthropic Messages |
| **Custom** | all three fields revealed, endpoint starts blank |

Pick a vendor, paste the key, done — the three values still go with the request, they're just not asked for. Vendors are tiles rather than a dropdown (three options, all visible at once, each captioned with what it implies), as a `radiogroup` of real buttons so it's keyboard- and screen-reader-navigable. OpenAI is selected on open.

The protocol control is on the **edit** form too, where the service *rejects* an unset protocol rather than defaulting it.

### Also

`formatAuthMethod` had no case for `x-api-key` and returned "Unspecified" — which is how every Anthropic provider has been listed in the table. The list also gained a sortable Protocol column.