### PR TITLE
Ask for the model the environment's mode can hold

### DIFF
--- a/src/__tests__/agent-create-environment.test.tsx
+++ b/src/__tests__/agent-create-environment.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PageTitleProvider } from '@/context/PageTitleContext';
-import { EntityMetaSchema, EnvironmentSchema } from '@/gen/agynio/api/agents/v1/agents_pb';
+import { EntityMetaSchema, EnvironmentSchema, LLMMode } from '@/gen/agynio/api/agents/v1/agents_pb';
 import { AgentCreatePage } from '@/pages/AgentCreatePage';
 
 const { createAgent, listEnvironments } = vi.hoisted(() => ({
@@ -65,6 +65,13 @@ describe('AgentCreatePage environment', () => {
           meta: create(EntityMetaSchema, { id: 'env-1' }),
           name: 'sandbox-env',
           image: 'ghcr.io/agynio/sandbox:latest',
+          llmMode: LLMMode.LLM_MODE_PLATFORM,
+        }),
+        create(EnvironmentSchema, {
+          meta: create(EntityMetaSchema, { id: 'env-native' }),
+          name: 'native-env',
+          image: 'ghcr.io/agynio/sandbox:latest',
+          llmMode: LLMMode.LLM_MODE_NATIVE,
         }),
       ],
       nextPageToken: '',
@@ -139,5 +146,116 @@ describe('AgentCreatePage environment', () => {
 
     const empty = await screen.findByTestId('agent-create-environment-empty');
     expect(empty.textContent).toContain('No environments in this organization.');
+  });
+});
+
+// A native environment has no platform model namespace, so the catalog picker
+// names nothing the server would accept there.
+describe('AgentCreatePage model', () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    createAgent.mockReset();
+    listEnvironments.mockReset();
+    listModels.mockReset();
+
+    listModels.mockResolvedValue({
+      models: [{ meta: { id: 'model-1' }, name: 'gpt-shaped' }],
+      nextPageToken: '',
+    });
+    listEnvironments.mockResolvedValue({
+      environments: [
+        create(EnvironmentSchema, {
+          meta: create(EntityMetaSchema, { id: 'env-1' }),
+          name: 'sandbox-env',
+          llmMode: LLMMode.LLM_MODE_PLATFORM,
+        }),
+        create(EnvironmentSchema, {
+          meta: create(EntityMetaSchema, { id: 'env-native' }),
+          name: 'native-env',
+          llmMode: LLMMode.LLM_MODE_NATIVE,
+        }),
+      ],
+      nextPageToken: '',
+    });
+    createAgent.mockResolvedValue({ agent: { meta: { id: 'agent-1' }, name: 'builder' } });
+  });
+
+  async function chooseEnvironment(name: string) {
+    await waitFor(() => expect(listEnvironments).toHaveBeenCalled());
+    const listbox = await openSelect('agent-create-environment');
+    fireEvent.click(await within(listbox).findByText(name));
+  }
+
+  it('takes a vendor model name in a native environment', async () => {
+    renderCreatePage();
+    await chooseEnvironment('native-env');
+
+    expect(screen.queryByTestId('agent-create-model-select')).toBeNull();
+    fireEvent.change(screen.getByTestId('agent-create-model-name'), {
+      target: { value: 'claude-sonnet-4-5' },
+    });
+    fireEvent.change(screen.getByTestId('agent-create-name'), { target: { value: 'builder' } });
+    fireEvent.click(screen.getByTestId('agent-create-submit'));
+
+    await waitFor(() => expect(createAgent).toHaveBeenCalled());
+    expect(createAgent.mock.calls[0][0]).toMatchObject({
+      environmentId: 'env-native',
+      model: '',
+      modelName: 'claude-sonnet-4-5',
+    });
+  });
+
+  it('keeps the catalog picker in a platform environment', async () => {
+    renderCreatePage();
+    await chooseEnvironment('sandbox-env');
+
+    expect(screen.queryByTestId('agent-create-model-name')).toBeNull();
+    const listbox = await openSelect('agent-create-model-select');
+    fireEvent.click(await within(listbox).findByText('gpt-shaped'));
+
+    fireEvent.change(screen.getByTestId('agent-create-name'), { target: { value: 'builder' } });
+    fireEvent.click(screen.getByTestId('agent-create-submit'));
+
+    await waitFor(() => expect(createAgent).toHaveBeenCalled());
+    expect(createAgent.mock.calls[0][0]).toMatchObject({
+      environmentId: 'env-1',
+      model: 'model-1',
+      modelName: '',
+    });
+  });
+
+  // The mode is unknown until an environment is named, and so is the field.
+  it('leaves the model picker disabled until an environment is chosen', async () => {
+    renderCreatePage();
+
+    await waitFor(() => expect(listEnvironments).toHaveBeenCalled());
+    const trigger = screen.getByTestId('agent-create-model-select');
+    expect(trigger.getAttribute('data-disabled')).not.toBeNull();
+
+    await chooseEnvironment('sandbox-env');
+    expect(screen.getByTestId('agent-create-model-select').getAttribute('data-disabled')).toBeNull();
+  });
+
+  // Repointing at the other mode invalidates whatever was picked before it.
+  it('drops a catalog model when the environment turns native', async () => {
+    renderCreatePage();
+    await chooseEnvironment('sandbox-env');
+
+    const models = await openSelect('agent-create-model-select');
+    fireEvent.click(await within(models).findByText('gpt-shaped'));
+    await chooseEnvironment('native-env');
+
+    fireEvent.change(screen.getByTestId('agent-create-name'), { target: { value: 'builder' } });
+    fireEvent.click(screen.getByTestId('agent-create-submit'));
+
+    await waitFor(() => expect(createAgent).toHaveBeenCalled());
+    expect(createAgent.mock.calls[0][0]).toMatchObject({ model: '', modelName: '' });
   });
 });

--- a/src/__tests__/agent-model-llm-mode.test.tsx
+++ b/src/__tests__/agent-model-llm-mode.test.tsx
@@ -1,0 +1,163 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { create } from '@bufbuild/protobuf';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PageTitleProvider } from '@/context/PageTitleContext';
+import {
+  AgentSchema,
+  EntityMetaSchema,
+  EnvironmentSchema,
+  LLMMode,
+} from '@/gen/agynio/api/agents/v1/agents_pb';
+import { AgentConfigurationTab } from '@/pages/agent-detail/AgentConfigurationTab';
+
+const { updateAgent, listEnvironments, listModels } = vi.hoisted(() => ({
+  updateAgent: vi.fn(),
+  listEnvironments: vi.fn(),
+  listModels: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  agentsClient: { updateAgent, listEnvironments },
+  llmClient: { listModels },
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function renderTab(agent: ReturnType<typeof create<typeof AgentSchema>>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <PageTitleProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/organizations/org-1/agents/agent-1']}>
+          <Routes>
+            <Route
+              path="/organizations/:id/agents/:agentId"
+              element={<AgentConfigurationTab agent={agent} organizationId="org-1" />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </PageTitleProvider>,
+  );
+}
+
+function agentIn(environmentId: string, fields: { model?: string; modelName?: string } = {}) {
+  return create(AgentSchema, {
+    meta: create(EntityMetaSchema, { id: 'agent-1' }),
+    name: 'builder',
+    nickname: 'builder',
+    environmentId,
+    ...fields,
+  });
+}
+
+async function openSelect(testId: string) {
+  fireEvent.click(screen.getByTestId(testId));
+  return screen.findByRole('listbox');
+}
+
+// The environment's llm_mode decides which of the two model references is
+// legal, and the server rejects the other outright.
+describe('AgentConfigurationTab model by LLM mode', () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    updateAgent.mockReset();
+    listEnvironments.mockReset();
+    listModels.mockReset();
+
+    listModels.mockResolvedValue({
+      models: [{ meta: { id: 'model-1' }, name: 'gpt-shaped' }],
+      nextPageToken: '',
+    });
+    listEnvironments.mockResolvedValue({
+      environments: [
+        create(EnvironmentSchema, {
+          meta: create(EntityMetaSchema, { id: 'env-1' }),
+          name: 'sandbox-env',
+          llmMode: LLMMode.LLM_MODE_PLATFORM,
+        }),
+        create(EnvironmentSchema, {
+          meta: create(EntityMetaSchema, { id: 'env-native' }),
+          name: 'native-env',
+          llmMode: LLMMode.LLM_MODE_NATIVE,
+        }),
+      ],
+      nextPageToken: '',
+    });
+    updateAgent.mockResolvedValue({ agent: { meta: { id: 'agent-1' } } });
+  });
+
+  it('reads back the vendor name a native agent holds', async () => {
+    renderTab(agentIn('env-native', { modelName: 'claude-sonnet-4-5' }));
+
+    expect(screen.getByTestId('agent-configuration-model-value').textContent).toBe(
+      'claude-sonnet-4-5',
+    );
+  });
+
+  it('edits a native agent through model_name, never model', async () => {
+    renderTab(agentIn('env-native', { modelName: 'claude-sonnet-4-5' }));
+
+    fireEvent.click(screen.getByTestId('agent-configuration-edit'));
+    await waitFor(() => expect(listEnvironments).toHaveBeenCalled());
+
+    const input = await screen.findByTestId('agent-configuration-model-name');
+    expect((input as HTMLInputElement).value).toBe('claude-sonnet-4-5');
+    expect(screen.queryByTestId('agent-configuration-model')).toBeNull();
+
+    fireEvent.change(input, { target: { value: 'claude-opus-4-1' } });
+    fireEvent.click(screen.getByTestId('agent-configuration-save'));
+
+    await waitFor(() => expect(updateAgent).toHaveBeenCalled());
+    expect(updateAgent.mock.calls[0][0]).toMatchObject({
+      id: 'agent-1',
+      model: '',
+      modelName: 'claude-opus-4-1',
+    });
+  });
+
+  it('edits a platform agent through the catalog, never model_name', async () => {
+    renderTab(agentIn('env-1', { model: 'model-1' }));
+
+    fireEvent.click(screen.getByTestId('agent-configuration-edit'));
+    await waitFor(() => expect(listEnvironments).toHaveBeenCalled());
+
+    expect(screen.queryByTestId('agent-configuration-model-name')).toBeNull();
+    fireEvent.click(screen.getByTestId('agent-configuration-save'));
+
+    await waitFor(() => expect(updateAgent).toHaveBeenCalled());
+    expect(updateAgent.mock.calls[0][0]).toMatchObject({ model: 'model-1', modelName: '' });
+  });
+
+  // Repointing at the other mode invalidates a reference the caller never
+  // mentioned, so the field starts over rather than carrying it across.
+  it('drops the catalog model when repointed at a native environment', async () => {
+    renderTab(agentIn('env-1', { model: 'model-1' }));
+
+    fireEvent.click(screen.getByTestId('agent-configuration-edit'));
+    await waitFor(() => expect(listEnvironments).toHaveBeenCalled());
+
+    const environments = await openSelect('agent-configuration-environment');
+    fireEvent.click(await within(environments).findByText('native-env'));
+
+    const input = await screen.findByTestId('agent-configuration-model-name');
+    expect((input as HTMLInputElement).value).toBe('');
+
+    fireEvent.click(screen.getByTestId('agent-configuration-save'));
+    await waitFor(() => expect(updateAgent).toHaveBeenCalled());
+    expect(updateAgent.mock.calls[0][0]).toMatchObject({
+      environmentId: 'env-native',
+      model: '',
+      modelName: '',
+    });
+  });
+});

--- a/src/__tests__/agent-roles-section.test.tsx
+++ b/src/__tests__/agent-roles-section.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Code, ConnectError } from '@connectrpc/connect';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { AgentAvailability, AgentRole, AgentRoleAssignmentSchema } from '@/gen/agynio/api/agents/v1/agents_pb';
+import { AgentRole, AgentRoleAssignmentSchema } from '@/gen/agynio/api/agents/v1/agents_pb';
 import {
   MembershipRole,
   MembershipSchema,
@@ -47,13 +47,13 @@ vi.mock('sonner', () => ({
   },
 }));
 
-function renderSection(availability = AgentAvailability.PRIVATE) {
+function renderSection() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <AgentRolesSection agentId="agent-1" organizationId="org-1" availability={availability} />
+      <AgentRolesSection agentId="agent-1" organizationId="org-1" />
     </QueryClientProvider>,
   );
 }
@@ -138,9 +138,7 @@ describe('AgentRolesSection', () => {
   });
 
   it('makes specific-user private sharing discoverable', async () => {
-    renderSection(AgentAvailability.PRIVATE);
-
-    expect(screen.getByTestId('agent-roles-availability').textContent).toContain('Private sharing active');
+    renderSection();
 
     expect(await screen.findByText('@owner-user')).toBeTruthy();
     expect(screen.getByText('identity-owner')).toBeTruthy();
@@ -148,12 +146,14 @@ describe('AgentRolesSection', () => {
     expect(screen.getByText('@maintainer-user')).toBeTruthy();
   });
 
-  it('explains the availability interaction before the agent is private', async () => {
-    renderSection(AgentAvailability.INTERNAL);
+  // Availability lives in Configuration; restating it here said nothing the
+  // list itself does not.
+  it('carries no availability badge or hint', async () => {
+    renderSection();
 
-    expect(screen.getByTestId('agent-roles-availability').textContent).toContain('Available when Private');
-    expect(screen.getByTestId('agent-roles-private-hint').textContent).toContain('set Availability to Private');
     expect(await screen.findByText('@owner-user')).toBeTruthy();
+    expect(screen.queryByTestId('agent-roles-availability')).toBeNull();
+    expect(screen.queryByTestId('agent-roles-private-hint')).toBeNull();
   });
 
   it('keeps the toolbar outside the roles table card', async () => {

--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -8,6 +8,7 @@ interface ScriptEditorProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElem
   helperText?: string;
   monospace?: boolean;
   minHeightClass?: string;
+  maxHeightClass?: string;
 }
 
 export function ScriptEditor({
@@ -16,6 +17,8 @@ export function ScriptEditor({
   helperText,
   monospace = false,
   minHeightClass = 'min-h-[140px]',
+  // long content scrolls inside the editor instead of growing past the surface holding it
+  maxHeightClass = 'max-h-[360px]',
   className = '',
   ...props
 }: ScriptEditorProps) {
@@ -23,7 +26,7 @@ export function ScriptEditor({
     <div className="w-full">
       {label ? <Label className="mb-2 block">{label}</Label> : null}
       <Textarea
-        className={`${minHeightClass} ${monospace ? 'font-mono' : ''} ${className}`}
+        className={`${minHeightClass} ${maxHeightClass} ${monospace ? 'font-mono' : ''} ${className}`}
         aria-invalid={Boolean(error)}
         {...props}
       />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -59,7 +59,8 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          // [&>*]:min-w-0 keeps wide content (long tokens, textareas) from stretching the grid past max-width
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none [&>*]:min-w-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
           className,
         )}
         {...props}

--- a/src/pages/AgentCreatePage.tsx
+++ b/src/pages/AgentCreatePage.tsx
@@ -12,6 +12,7 @@ import {
   AgentAvailability,
   AgentDefaultThread,
   AgentFinalMessage,
+  LLMMode,
 } from '@/gen/agynio/api/agents/v1/agents_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { NO_MODEL } from '@/lib/constants';
@@ -32,7 +33,10 @@ export function AgentCreatePage() {
   const [nickname, setNickname] = useState('');
   const [nicknameError, setNicknameError] = useState('');
   const [role, setRole] = useState('');
-  const [modelId, setModelId] = useState(NO_MODEL);
+  // Empty rather than NO_MODEL: unchosen has to read as unchosen, and only an
+  // unmatched value lets the trigger show its placeholder.
+  const [modelId, setModelId] = useState('');
+  const [modelName, setModelName] = useState('');
   const [description, setDescription] = useState('');
   const [environmentId, setEnvironmentId] = useState('');
   const [environmentError, setEnvironmentError] = useState('');
@@ -67,12 +71,19 @@ export function AgentCreatePage() {
     [environmentsQuery.data?.environments],
   );
 
+  // Which of the two model references is legal is the environment's to decide,
+  // so the field only exists once one is chosen.
+  const isNative =
+    environments.find((environment) => environment.meta?.id === environmentId)?.llmMode ===
+    LLMMode.LLM_MODE_NATIVE;
+
   const createAgentMutation = useMutation({
     mutationFn: (payload: {
       name: string;
       nickname: string;
       role: string;
       model: string;
+      modelName: string;
       description: string;
       configuration: string;
       environmentId: string;
@@ -146,7 +157,10 @@ export function AgentCreatePage() {
       name: trimmedName,
       nickname: trimmedNickname,
       role: role.trim(),
-      model: modelId === NO_MODEL ? '' : modelId,
+      // The server rejects the reference the environment's mode has no namespace
+      // for, so only the one the mode owns is sent.
+      model: isNative || modelId === NO_MODEL ? '' : modelId,
+      modelName: isNative ? modelName.trim() : '',
       description: description.trim(),
       configuration: trimmedConfig,
       environmentId,
@@ -210,46 +224,17 @@ export function AgentCreatePage() {
               data-testid="agent-create-role"
             />
           </div>
-          <div className="space-y-2" data-testid="agent-create-model">
-            <Label htmlFor="agent-create-model-select">Model</Label>
-            <Select
-              value={modelId}
-              onValueChange={(value) => setModelId(value)}
-              disabled={modelsQuery.isPending}
-            >
-              <SelectTrigger id="agent-create-model-select" data-testid="agent-create-model-select">
-                <SelectValue placeholder={modelsQuery.isPending ? 'Loading models...' : 'Select model'} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={NO_MODEL}>None</SelectItem>
-                {models.map((model) => {
-                  const modelValue = model.meta?.id;
-                  if (!modelValue) return null;
-                  return (
-                    <SelectItem key={modelValue} value={modelValue}>
-                      {model.name || 'Unnamed model'}
-                    </SelectItem>
-                  );
-                })}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="agent-create-description">Description</Label>
-            <Input
-              id="agent-create-description"
-              placeholder="Explain what this agent does"
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-              data-testid="agent-create-description"
-            />
-          </div>
+          {/* Before the model: which kind of model reference the agent can hold
+              is this field's answer to give. */}
           <div className="space-y-2">
             <Label htmlFor="agent-create-environment">Environment</Label>
             <Select
               value={environmentId}
               onValueChange={(value) => {
                 setEnvironmentId(value);
+                // Each reference is meaningless in the other mode.
+                setModelId('');
+                setModelName('');
                 if (environmentError) setEnvironmentError('');
               }}
             >
@@ -288,6 +273,74 @@ export function AgentCreatePage() {
                 attached to it.
               </p>
             )}
+          </div>
+          <div className="space-y-2" data-testid="agent-create-model">
+            <Label htmlFor={isNative ? 'agent-create-model-name' : 'agent-create-model-select'}>
+              Model
+            </Label>
+            {isNative ? (
+              <>
+                <Input
+                  id="agent-create-model-name"
+                  placeholder="claude-sonnet-4-5"
+                  value={modelName}
+                  onChange={(event) => setModelName(event.target.value)}
+                  data-testid="agent-create-model-name"
+                />
+                <p className="text-xs text-muted-foreground">
+                  A native environment has no platform catalog, so name the vendor&apos;s own model
+                  and the agent CLI is pinned to it. Leave it empty to keep the CLI&apos;s default.
+                </p>
+              </>
+            ) : (
+              <>
+                <Select
+                  value={modelId}
+                  onValueChange={(value) => setModelId(value)}
+                  disabled={!environmentId || modelsQuery.isPending}
+                >
+                  <SelectTrigger id="agent-create-model-select" data-testid="agent-create-model-select">
+                    <SelectValue
+                      placeholder={
+                        !environmentId
+                          ? 'Select an environment first'
+                          : modelsQuery.isPending
+                            ? 'Loading models...'
+                            : 'Select model'
+                      }
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NO_MODEL}>None</SelectItem>
+                    {models.map((model) => {
+                      const modelValue = model.meta?.id;
+                      if (!modelValue) return null;
+                      return (
+                        <SelectItem key={modelValue} value={modelValue}>
+                          {model.name || 'Unnamed model'}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+                {!environmentId ? (
+                  <p className="text-xs text-muted-foreground">
+                    The environment decides where models come from — the platform catalog, or the
+                    vendor the agent CLI addresses itself.
+                  </p>
+                ) : null}
+              </>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="agent-create-description">Description</Label>
+            <Input
+              id="agent-create-description"
+              placeholder="Explain what this agent does"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              data-testid="agent-create-description"
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="agent-create-availability">Availability</Label>

--- a/src/pages/AgentDetailPage.tsx
+++ b/src/pages/AgentDetailPage.tsx
@@ -60,7 +60,6 @@ export function AgentDetailPage() {
           parentLabel="Agents"
           parentHref={`/organizations/${organizationId}/agents`}
           title={agent.name || 'Agent'}
-          meta={[agent.model, agent.environmentId ? 'environment set' : ''].filter(Boolean).join(' · ')}
           actions={
             <Button
               variant="outline"
@@ -116,7 +115,7 @@ export function AgentDetailPage() {
             <EgressRuleAttachmentsTab target={{ kind: 'agent', id: resolvedAgentId }} organizationId={organizationId} />
           </TabsContent>
           <TabsContent value="roles">
-            <AgentRolesSection agentId={resolvedAgentId} organizationId={organizationId} availability={agent.availability} />
+            <AgentRolesSection agentId={resolvedAgentId} organizationId={organizationId} />
           </TabsContent>
         </Tabs>
         </>

--- a/src/pages/agent-detail/AgentConfigurationTab.tsx
+++ b/src/pages/agent-detail/AgentConfigurationTab.tsx
@@ -20,6 +20,7 @@ import {
   AgentAvailability,
   AgentDefaultThread,
   AgentFinalMessage,
+  LLMMode,
   type Agent,
 } from '@/gen/agynio/api/agents/v1/agents_pb';
 import { NO_MODEL } from '@/lib/constants';
@@ -53,6 +54,7 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
   const [nicknameError, setNicknameError] = useState('');
   const [role, setRole] = useState('');
   const [modelId, setModelId] = useState(NO_MODEL);
+  const [modelName, setModelName] = useState('');
   const [description, setDescription] = useState('');
   const [environmentId, setEnvironmentId] = useState('');
   const [environmentError, setEnvironmentError] = useState('');
@@ -80,6 +82,14 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
   // The agent stores an id; the read view shows what a person recognises.
   const environmentName = (id: string) =>
     id ? (environments.find((environment) => environment.meta?.id === id)?.name ?? id) : '';
+
+  const isNativeEnvironment = (id: string) =>
+    environments.find((environment) => environment.meta?.id === id)?.llmMode ===
+    LLMMode.LLM_MODE_NATIVE;
+
+  // Which of the two model references is legal is the environment's to decide,
+  // so the edited environment governs the field, not the saved one.
+  const isNative = isNativeEnvironment(environmentId);
 
   const modelsQuery = useQuery({
     queryKey: ['llm', organizationId, 'models', 'all'],
@@ -116,6 +126,7 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
       name?: string;
       role?: string;
       model?: string;
+      modelName?: string;
       description?: string;
       configuration?: string;
       environmentId?: string;
@@ -144,6 +155,7 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
       setNickname(agent.nickname);
       setRole(agent.role);
       setModelId(agent.model || NO_MODEL);
+      setModelName(agent.modelName);
       setDescription(agent.description);
       setEnvironmentId(agent.environmentId);
       setConfiguration(agent.configuration);
@@ -211,7 +223,10 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
       name: trimmedName,
       nickname: trimmedNickname,
       role: role.trim(),
-      model: modelId === NO_MODEL ? '' : modelId,
+      // The server rejects the reference the environment's mode has no namespace
+      // for, so only the one the mode owns is sent.
+      model: isNative || modelId === NO_MODEL ? '' : modelId,
+      modelName: isNative ? modelName.trim() : '',
       description: description.trim(),
       configuration: trimmedConfig,
       environmentId,
@@ -257,8 +272,9 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
             </div>
             <div>
               <div className="text-xs uppercase tracking-wide text-muted-foreground">Model</div>
-              <div className="text-sm text-foreground">
-                {modelMap.get(agent.model)?.name ?? (agent.model || '—')}
+              {/* A native agent holds a vendor name instead of a catalog id. */}
+              <div className="text-sm text-foreground" data-testid="agent-configuration-model-value">
+                {agent.modelName || modelMap.get(agent.model)?.name || agent.model || '—'}
               </div>
             </div>
             <div>
@@ -361,40 +377,19 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
                 data-testid="agent-configuration-role"
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="agent-configuration-model">Model</Label>
-              <Select value={modelId} onValueChange={(value) => setModelId(value)}>
-                <SelectTrigger id="agent-configuration-model" data-testid="agent-configuration-model">
-                  <SelectValue placeholder="Select model" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NO_MODEL}>None</SelectItem>
-                  {(modelsQuery.data?.models ?? []).map((model) => {
-                    const modelValue = model.meta?.id;
-                    if (!modelValue) return null;
-                    return (
-                      <SelectItem key={modelValue} value={modelValue}>
-                        {model.name || 'Unnamed model'}
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="agent-configuration-description">Description</Label>
-              <Input
-                id="agent-configuration-description"
-                value={description}
-                onChange={(event) => setDescription(event.target.value)}
-                data-testid="agent-configuration-description"
-              />
-            </div>
+            {/* Before the model: which kind of model reference the agent can hold
+                is this field's answer to give. */}
             <div className="space-y-2">
               <Label htmlFor="agent-configuration-environment">Environment</Label>
               <Select
                 value={environmentId}
                 onValueChange={(value) => {
+                  // Each reference is meaningless in the other mode, so a repoint
+                  // across modes starts the field over.
+                  if (isNativeEnvironment(value) !== isNative) {
+                    setModelId('');
+                    setModelName('');
+                  }
                   setEnvironmentId(value);
                   if (environmentError) setEnvironmentError('');
                 }}
@@ -415,6 +410,53 @@ export function AgentConfigurationTab({ agent, organizationId }: AgentConfigurat
                   {environmentError}
                 </p>
               ) : null}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={isNative ? 'agent-configuration-model-name' : 'agent-configuration-model'}>
+                Model
+              </Label>
+              {isNative ? (
+                <>
+                  <Input
+                    id="agent-configuration-model-name"
+                    placeholder="claude-sonnet-4-5"
+                    value={modelName}
+                    onChange={(event) => setModelName(event.target.value)}
+                    data-testid="agent-configuration-model-name"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    A native environment has no platform catalog, so name the vendor&apos;s own model
+                    and the agent CLI is pinned to it. Leave it empty to keep the CLI&apos;s default.
+                  </p>
+                </>
+              ) : (
+                <Select value={modelId} onValueChange={(value) => setModelId(value)}>
+                  <SelectTrigger id="agent-configuration-model" data-testid="agent-configuration-model">
+                    <SelectValue placeholder="Select model" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NO_MODEL}>None</SelectItem>
+                    {(modelsQuery.data?.models ?? []).map((model) => {
+                      const modelValue = model.meta?.id;
+                      if (!modelValue) return null;
+                      return (
+                        <SelectItem key={modelValue} value={modelValue}>
+                          {model.name || 'Unnamed model'}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="agent-configuration-description">Description</Label>
+              <Input
+                id="agent-configuration-description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                data-testid="agent-configuration-description"
+              />
             </div>
             <div className="space-y-2">
               <Label htmlFor="agent-configuration-availability">Availability</Label>

--- a/src/pages/agent-detail/AgentRolesSection.tsx
+++ b/src/pages/agent-detail/AgentRolesSection.tsx
@@ -17,7 +17,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { AgentAvailability, AgentRole, type AgentRoleAssignment } from '@/gen/agynio/api/agents/v1/agents_pb';
+import { AgentRole, type AgentRoleAssignment } from '@/gen/agynio/api/agents/v1/agents_pb';
 import { AgentsGateway } from '@/gen/agynio/api/gateway/v1/agents_pb';
 import { MembershipStatus, type Membership } from '@/gen/agynio/api/organizations/v1/organizations_pb';
 import { formatAgentRole } from '@/lib/format';
@@ -27,7 +27,6 @@ import { toast } from 'sonner';
 type AgentRolesSectionProps = {
   agentId: string;
   organizationId: string;
-  availability: AgentAvailability;
 };
 
 const assignableRoles = [AgentRole.OWNER, AgentRole.MAINTAINER, AgentRole.PARTICIPANT] as const;
@@ -69,7 +68,7 @@ function formatRoleError(error: unknown, fallback: string) {
   return error instanceof Error ? error.message : fallback;
 }
 
-export function AgentRolesSection({ agentId, organizationId, availability }: AgentRolesSectionProps) {
+export function AgentRolesSection({ agentId, organizationId }: AgentRolesSectionProps) {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedIdentityId, setSelectedIdentityId] = useState('');
@@ -206,20 +205,10 @@ export function AgentRolesSection({ agentId, organizationId, availability }: Age
             data-testid="agent-roles-search"
           />
         </div>
-        <div className="flex items-center gap-2">
-          <Badge variant={availability === AgentAvailability.PRIVATE ? 'default' : 'outline'} data-testid="agent-roles-availability">
-            {availability === AgentAvailability.PRIVATE ? 'Private sharing active' : 'Available when Private'}
-          </Badge>
-          <Button variant="outline" size="sm" onClick={() => openEdit()} data-testid="agent-roles-add">
-            Share agent
-          </Button>
-        </div>
+        <Button variant="outline" size="sm" onClick={() => openEdit()} data-testid="agent-roles-add">
+          Share agent
+        </Button>
       </div>
-      {availability !== AgentAvailability.PRIVATE ? (
-        <div className="rounded-md border border-border bg-muted/40 p-3 text-sm text-muted-foreground" data-testid="agent-roles-private-hint">
-          To limit thread access to only the users listed here, set Availability to Private in Configuration.
-        </div>
-      ) : null}
       {rolesQuery.isPending ? <div className="text-sm text-muted-foreground">Loading roles...</div> : null}
       {rolesQuery.isError ? (
         <div className="text-sm text-destructive" data-testid="agent-roles-load-error">


### PR DESCRIPTION
Creating an agent in a native environment failed outright:

```
[invalid_argument] model is rejected in a native environment, which has no
platform model namespace; set model_name instead
```

The console only ever knew about `model`. The service treats the two references as required-and-exclusive per mode ([`resolveAgentModel`](https://github.com/agynio/agents/blob/main/internal/server/server.go)): a platform environment owns a model namespace and takes a catalog UUID; a native one has none and takes an opaque vendor string.

## What changed

**The form asks for whichever reference the chosen environment can hold**, and sends only that one — free-text `model_name` in native mode (optional; empty leaves the CLI on its own default), the catalog picker in platform mode.

**Environment moved above Model** on both the create page and the edit dialog. It is the field that decides what Model can even be, and asking in the other order is what let the mismatch be composed. Until an environment is named the picker is disabled and says so.

**The edit dialog had the same fault** — an agent created in a native environment through the CLI could not be edited from the console at all, since every save carried `model`. Its read-only Model row now prefers `model_name`; it showed an em dash before.

**Repointing across modes** clears the reference the target mode has no namespace for.

## Cleanup this surfaced

- The agent header carried the model UUID plus the words "environment set". For a native agent that UUID reads back as `uuid.Nil`, so the line said `00000000-…-000000000000` and nothing else. Removed.
- The Roles tab stated availability twice — a badge and a hint pointing at Configuration. Availability is editable there and only there. Both removed, along with the now-dead `availability` prop.
- A dialog no longer stretches past its max width when it holds a long token or a textarea; `ScriptEditor` scrolls long content instead of growing past its container.

## Verification

- New `agent-model-llm-mode.test.tsx` covers the edit dialog in both modes; 4 cases added to `agent-create-environment.test.tsx` for the create page.
- 283 tests / 51 files pass, typecheck clean, lint clean apart from two pre-existing warnings in an untouched file.
- Exercised against the local VM (`console.agyn.dev:2496`) running from source.