### PR TITLE
Count cached tokens once, and show the subscription ones

### DIFF
--- a/src/__tests__/organization-overview.test.tsx
+++ b/src/__tests__/organization-overview.test.tsx
@@ -104,7 +104,14 @@ describe('OrganizationOverviewTab dashboard', () => {
 
   it('reads tokens, compute and threads over the last week', async () => {
     mocks.queryUsage.mockImplementation(async (request: { unit: Unit; labelFilters?: Record<string, string> }) => {
-      if (request.unit === Unit.TOKENS) return { buckets: [{ value: micros(128_000) }] };
+      if (request.unit === Unit.TOKENS) {
+        return {
+          buckets: [
+            { value: micros(120_000), groupValue: 'input' },
+            { value: micros(8_000), groupValue: 'output' },
+          ],
+        };
+      }
       if (request.unit === Unit.FLAVOR_SECONDS) return { buckets: [{ value: micros(9_000) }] };
       if (request.labelFilters?.kind === 'thread') return { buckets: [{ value: micros(6) }] };
       if (request.labelFilters?.kind === 'message') return { buckets: [{ value: micros(42) }] };
@@ -122,6 +129,28 @@ describe('OrganizationOverviewTab dashboard', () => {
     expect(threads.textContent).toContain('42 messages');
   });
 
+  // Cached tokens are the share of the input that was served from cache, not
+  // tokens spent on top of it. Adding the kinds up counts that share twice, and
+  // the headline came out two thirds larger than the traffic behind it.
+  it('does not count cached tokens on top of the input they came from', async () => {
+    mocks.queryUsage.mockImplementation(async (request: { unit: Unit }) => {
+      if (request.unit !== Unit.TOKENS) return { buckets: [] };
+      return {
+        buckets: [
+          { value: micros(85_227), groupValue: 'input' },
+          { value: micros(57_856), groupValue: 'cached' },
+          { value: micros(772), groupValue: 'output' },
+        ],
+      };
+    });
+
+    renderOverview();
+
+    const tokens = await screen.findByTestId('organization-overview-tokens');
+    await waitFor(() => expect(tokens.textContent).toContain('86K'));
+    expect(tokens.textContent).not.toContain('143.9K');
+  });
+
   it('compares the week against the one before it', async () => {
     // Both windows end where the other begins, so the earlier request is the
     // one whose start is further back.
@@ -129,7 +158,7 @@ describe('OrganizationOverviewTab dashboard', () => {
       if (request.unit !== Unit.TOKENS) return { buckets: [] };
       const startedAt = Number(request.start?.seconds ?? 0n) * 1000;
       const isPreviousWeek = Date.now() - startedAt > 8 * 24 * HOUR_MS;
-      return { buckets: [{ value: micros(isPreviousWeek ? 41_000 : 128_000) }] };
+      return { buckets: [{ value: micros(isPreviousWeek ? 41_000 : 128_000), groupValue: 'input' }] };
     });
 
     renderOverview();
@@ -147,8 +176,8 @@ describe('OrganizationOverviewTab dashboard', () => {
       }
       return {
         buckets: [
-          { value: micros(246_326), timestamp: dayTimestamp(1) },
-          { value: micros(217_874), timestamp: dayTimestamp(0) },
+          { value: micros(246_326), timestamp: dayTimestamp(1), groupValue: 'input' },
+          { value: micros(217_874), timestamp: dayTimestamp(0), groupValue: 'input' },
         ],
       };
     });
@@ -169,6 +198,7 @@ describe('OrganizationOverviewTab dashboard', () => {
         buckets: Array.from({ length: 7 }, (_, index) => ({
           value: micros(1_000),
           timestamp: dayTimestamp(index),
+          groupValue: 'input',
         })),
       };
     });

--- a/src/__tests__/organization-usage-tabs.test.tsx
+++ b/src/__tests__/organization-usage-tabs.test.tsx
@@ -41,6 +41,11 @@ function unitsRequested(): Set<Unit> {
   return new Set(queryUsage.mock.calls.map(([request]) => (request as { unit: Unit }).unit));
 }
 
+/** Metering reports every value in micros. */
+function micros(value: number): bigint {
+  return BigInt(value) * 1_000_000n;
+}
+
 describe('usage tabs', () => {
   afterEach(() => {
     cleanup();
@@ -89,5 +94,29 @@ describe('usage tabs', () => {
       expect(screen.queryByTestId('organization-usage-compute-empty')).not.toBeNull();
     });
     expect(screen.getByTestId('organization-usage-compute-empty').textContent).toContain('No compute usage');
+  });
+
+  // Every spend figure here filters to resource=model, so an organization whose
+  // work all ran on a subscription read as an empty tab while the Overview
+  // counted the same tokens. A flat fee is not spend, but it is usage.
+  it('reports subscription tokens the spend figures leave out', async () => {
+    listModels.mockResolvedValue({ models: [] });
+    queryUsage.mockImplementation(async (request: { labelFilters?: Record<string, string> }) => {
+      const filters = request.labelFilters ?? {};
+      if (filters.resource !== 'subscription') return create(QueryUsageResponseSchema, { buckets: [] });
+      if (filters.kind === 'input') return create(QueryUsageResponseSchema, { buckets: [{ value: micros(85_227) }] });
+      if (filters.kind === 'output') return create(QueryUsageResponseSchema, { buckets: [{ value: micros(772) }] });
+      return create(QueryUsageResponseSchema, { buckets: [] });
+    });
+
+    renderUsageTab();
+
+    const card = await screen.findByTestId('organization-usage-llm-subscription');
+    await waitFor(() => expect(card.textContent).toContain('85,999'));
+    expect(card.textContent).toContain('not billed');
+    expect(screen.queryByTestId('organization-usage-llm-empty')).toBeNull();
+    // The billable figures stay filtered: none of this belongs in them.
+    expect(screen.getByTestId('organization-usage-llm-input').textContent).toContain('0');
+    expect(screen.getByTestId('organization-usage-llm-output').textContent).toContain('0');
   });
 });

--- a/src/__tests__/usage-spend-excludes-subscriptions.test.ts
+++ b/src/__tests__/usage-spend-excludes-subscriptions.test.ts
@@ -14,16 +14,29 @@ const source = [
 
 // A subscription is a flat fee: its tokens have no marginal cost, and summing
 // them alongside API tokens produces a bill that does not exist. The only thing
-// keeping the two apart is the resource label, so every token query that feeds
-// a spend view has to carry the filter.
+// keeping the two apart is the resource label, so every token query has to name
+// which side it reads -- an unfiltered one silently mixes them back together.
 describe('usage spend views', () => {
-  it('filters token queries to resource=model', () => {
+  it('names a resource on every token query', () => {
     const tokenQueries = source
       .split(/\n\s*\{/)
       .filter((block) => block.includes('unit: Unit.TOKENS'));
 
     expect(tokenQueries.length).toBeGreaterThan(0);
     for (const block of tokenQueries) {
+      expect(block).toMatch(/METERED_MODEL_TOKENS|SUBSCRIPTION_TOKENS/);
+    }
+  });
+
+  // The rankings and the headline figures are the spend views proper. Only the
+  // queries that opt into the subscription side may leave resource=model.
+  it('keeps subscription tokens out of the consumer rankings', () => {
+    const consumerQueries = source
+      .split(/\n\s*\{/)
+      .filter((block) => block.includes('unit: Unit.TOKENS') && block.includes('llm-consumers-'));
+
+    expect(consumerQueries.length).toBeGreaterThan(0);
+    for (const block of consumerQueries) {
       expect(block).toContain('METERED_MODEL_TOKENS');
     }
   });

--- a/src/lib/usageConsumers.ts
+++ b/src/lib/usageConsumers.ts
@@ -16,6 +16,11 @@ export type UsageQueryConfig = {
 // distinct resource value is the only thing keeping the two apart.
 export const METERED_MODEL_TOKENS = { resource: 'model' } as const;
 
+// The other half of that split, shown apart rather than summed in. Without it
+// the LLM tab reads as empty for an organization running on a subscription,
+// which is the whole of its usage and none of its bill.
+export const SUBSCRIPTION_TOKENS = { resource: 'subscription' } as const;
+
 /** The sections with a consumer ranking. Each picks its own level. */
 export type ConsumerMetric = 'llm' | 'compute' | 'storage';
 

--- a/src/pages/overview/OverviewActivity.tsx
+++ b/src/pages/overview/OverviewActivity.tsx
@@ -4,7 +4,6 @@ import { TrendingDownIcon, TrendingUpIcon } from 'lucide-react';
 import { ChartTooltip } from '@/components/ChartTooltip';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { timestampToMillis } from '@/lib/format';
 import { formatUsageCompact, formatUsageNumber, microsToHours, microsToNumber } from '@/lib/usage';
 import { ACTIVITY_WINDOW_DAYS, DAY_MS, useOverviewActivity } from './useOverviewActivity';
 
@@ -65,9 +64,8 @@ export function OverviewActivity({ organizationId, runnerCount }: OverviewActivi
   // old should not be shown five days of nothing it could not have used.
   const series = useMemo(() => {
     const byDay = new Map<string, number>();
-    activity.daily.forEach((bucket) => {
-      const millis = timestampToMillis(bucket.timestamp);
-      if (millis) byDay.set(dayKey(new Date(millis)), microsToNumber(bucket.value));
+    activity.daily.forEach((day) => {
+      byDay.set(dayKey(new Date(day.millis)), microsToNumber(day.tokens));
     });
 
     const days = Array.from({ length: ACTIVITY_WINDOW_DAYS }, (_, index) => {

--- a/src/pages/overview/useOverviewActivity.ts
+++ b/src/pages/overview/useOverviewActivity.ts
@@ -1,10 +1,21 @@
 import { useMemo } from 'react';
 import { useQueries } from '@tanstack/react-query';
 import { Granularity, Unit, type UsageBucket } from '@/gen/agynio/api/metering/v1/metering_pb';
+import { timestampToMillis } from '@/lib/format';
 import { queryUsage, sumUsageBuckets } from '@/lib/metering';
 
 export const DAY_MS = 86_400_000;
 export const ACTIVITY_WINDOW_DAYS = 7;
+
+/**
+ * Cached tokens are the share of the input that came from cache, not tokens on
+ * top of it -- the LLM tab draws them as `input - cached` for the same reason.
+ * Summing every kind counts that share twice, so the kinds are named.
+ */
+const COUNTED_TOKEN_KINDS = new Set(['input', 'output']);
+
+/** A day of the token chart, already folded across the kinds that count. */
+export type DailyTokens = { millis: number; tokens: bigint };
 
 export type ActivityUsage = {
   /** Tokens over the window, and over the window before it, for the comparison. */
@@ -15,7 +26,7 @@ export type ActivityUsage = {
   threads: bigint;
   messages: bigint;
   /** Only days with usage come back, so the chart fills the rest itself. */
-  daily: UsageBucket[];
+  daily: DailyTokens[];
   end: Date;
   isPending: boolean;
   isError: boolean;
@@ -28,7 +39,23 @@ type ActivityQuery = {
   start: Date;
   end?: Date;
   labelFilters?: Record<string, string>;
+  groupBy?: string;
 };
+
+function sumTokenBuckets(buckets: UsageBucket[]): bigint {
+  return sumUsageBuckets(buckets.filter((bucket) => COUNTED_TOKEN_KINDS.has(bucket.groupValue)));
+}
+
+function foldDailyTokens(buckets: UsageBucket[]): DailyTokens[] {
+  const byDay = new Map<number, bigint>();
+  buckets.forEach((bucket) => {
+    if (!COUNTED_TOKEN_KINDS.has(bucket.groupValue)) return;
+    const millis = timestampToMillis(bucket.timestamp);
+    if (!millis) return;
+    byDay.set(millis, (byDay.get(millis) ?? 0n) + bucket.value);
+  });
+  return Array.from(byDay, ([millis, tokens]) => ({ millis, tokens }));
+}
 
 /**
  * The window both the figures and the chart are read over. Rounded down to the
@@ -50,21 +77,25 @@ function activityRange(): { start: Date; end: Date; previousStart: Date } {
  * subscription tokens because they are a flat fee and summing them produces a
  * bill that does not exist -- but this is a readout of what the organization
  * did, and a subscription's tokens are tokens it spent.
+ *
+ * They group by kind rather than filtering to one, because the figure wants two
+ * of the three kinds and a filter only ever names one.
  */
 export function useOverviewActivity(organizationId: string): ActivityUsage {
   const range = useMemo(activityRange, [organizationId]);
 
   const configs = useMemo<ActivityQuery[]>(
     () => [
-      { key: 'tokens', unit: Unit.TOKENS, granularity: Granularity.TOTAL, start: range.start },
+      { key: 'tokens', unit: Unit.TOKENS, granularity: Granularity.TOTAL, start: range.start, groupBy: 'kind' },
       {
         key: 'tokens-previous',
         unit: Unit.TOKENS,
         granularity: Granularity.TOTAL,
         start: range.previousStart,
         end: range.start,
+        groupBy: 'kind',
       },
-      { key: 'tokens-daily', unit: Unit.TOKENS, granularity: Granularity.DAY, start: range.start },
+      { key: 'tokens-daily', unit: Unit.TOKENS, granularity: Granularity.DAY, start: range.start, groupBy: 'kind' },
       { key: 'compute', unit: Unit.FLAVOR_SECONDS, granularity: Granularity.TOTAL, start: range.start },
       {
         key: 'threads',
@@ -95,6 +126,7 @@ export function useOverviewActivity(organizationId: string): ActivityUsage {
           unit: config.unit,
           granularity: config.granularity,
           labelFilters: config.labelFilters,
+          groupBy: config.groupBy,
         }),
       enabled: Boolean(organizationId),
       staleTime: 60_000,
@@ -105,12 +137,12 @@ export function useOverviewActivity(organizationId: string): ActivityUsage {
   const [tokens, previousTokens, daily, compute, threads, messages] = results;
 
   return {
-    tokens: sumUsageBuckets(tokens.data?.buckets ?? []),
-    previousTokens: sumUsageBuckets(previousTokens.data?.buckets ?? []),
+    tokens: sumTokenBuckets(tokens.data?.buckets ?? []),
+    previousTokens: sumTokenBuckets(previousTokens.data?.buckets ?? []),
     compute: sumUsageBuckets(compute.data?.buckets ?? []),
     threads: sumUsageBuckets(threads.data?.buckets ?? []),
     messages: sumUsageBuckets(messages.data?.buckets ?? []),
-    daily: daily.data?.buckets ?? [],
+    daily: foldDailyTokens(daily.data?.buckets ?? []),
     end: range.end,
     isPending: results.some((result) => result.isPending),
     isError: results.some((result) => result.isError),

--- a/src/pages/usage/LlmSection.tsx
+++ b/src/pages/usage/LlmSection.tsx
@@ -22,6 +22,7 @@ import { MAX_PAGE_SIZE } from '@/lib/pagination';
 import { formatUsageNumber, formatUsageValue, microsToNumber } from '@/lib/usage';
 import {
   METERED_MODEL_TOKENS,
+  SUBSCRIPTION_TOKENS,
   consumerQueryConfigs,
   consumerQuerySources,
   identifiedGroupTotals,
@@ -73,6 +74,33 @@ const fixedConfigs: UsageQueryConfig[] = [
     labelFilters: { ...METERED_MODEL_TOKENS, kind: 'output' },
     groupBy: 'resource_id',
   },
+  // Subscription tokens are read on their own rather than through the spend
+  // queries above. A native call runs against a Subscription, so it carries no
+  // Model to resolve -- model_name is what names which model actually ran.
+  { key: 'llm-subscription-input-total', unit: Unit.TOKENS, granularity: Granularity.TOTAL, labelFilters: { ...SUBSCRIPTION_TOKENS, kind: 'input' } },
+  { key: 'llm-subscription-output-total', unit: Unit.TOKENS, granularity: Granularity.TOTAL, labelFilters: { ...SUBSCRIPTION_TOKENS, kind: 'output' } },
+  {
+    key: 'llm-subscription-daily-tokens',
+    unit: Unit.TOKENS,
+    granularity: Granularity.DAY,
+    useRangeGranularity: true,
+    labelFilters: { ...SUBSCRIPTION_TOKENS },
+    groupBy: 'kind',
+  },
+  {
+    key: 'llm-subscription-models-input-total',
+    unit: Unit.TOKENS,
+    granularity: Granularity.TOTAL,
+    labelFilters: { ...SUBSCRIPTION_TOKENS, kind: 'input' },
+    groupBy: 'model_name',
+  },
+  {
+    key: 'llm-subscription-models-output-total',
+    unit: Unit.TOKENS,
+    granularity: Granularity.TOTAL,
+    labelFilters: { ...SUBSCRIPTION_TOKENS, kind: 'output' },
+    groupBy: 'model_name',
+  },
 ];
 
 type TokenPoint = {
@@ -80,31 +108,62 @@ type TokenPoint = {
   uncached: number;
   cached: number;
   output: number;
+  subscriptionInput: number;
+  subscriptionOutput: number;
 };
 
-function buildTokenSeries(buckets: UsageBucket[], granularity: Granularity, range: UsageRange): TokenPoint[] {
+const emptyPoint = (timestamp: number): TokenPoint => ({
+  timestamp,
+  uncached: 0,
+  cached: 0,
+  output: 0,
+  subscriptionInput: 0,
+  subscriptionOutput: 0,
+});
+
+/**
+ * The subscription side is one segment per panel where the billable side is
+ * split by cache. The stacks still measure the same thing: uncached + cached is
+ * the input, so a subscription bar of that height is read against it directly.
+ */
+function buildTokenSeries(
+  buckets: UsageBucket[],
+  subscriptionBuckets: UsageBucket[],
+  granularity: Granularity,
+  range: UsageRange,
+): TokenPoint[] {
   const byTimestamp = new Map<number, TokenPoint>();
+  const pointAt = (bucket: UsageBucket) => {
+    const timestamp = bucketTimestamp(bucket);
+    const point = byTimestamp.get(timestamp) ?? emptyPoint(timestamp);
+    byTimestamp.set(timestamp, point);
+    return point;
+  };
+
   buckets.forEach((bucket) => {
     if (!bucket.timestamp) return;
-    const timestamp = bucketTimestamp(bucket);
-    const point = byTimestamp.get(timestamp) ?? { timestamp, uncached: 0, cached: 0, output: 0 };
+    const point = pointAt(bucket);
     const value = microsToNumber(bucket.value);
     if (bucket.groupValue === 'input') point.uncached += value;
     if (bucket.groupValue === 'cached') point.cached += value;
     if (bucket.groupValue === 'output') point.output += value;
-    byTimestamp.set(timestamp, point);
+  });
+
+  // Cached is the share of the input served from cache, not tokens on top of
+  // it, so it is left out here rather than added to the segment beside it.
+  subscriptionBuckets.forEach((bucket) => {
+    if (!bucket.timestamp) return;
+    const point = pointAt(bucket);
+    const value = microsToNumber(bucket.value);
+    if (bucket.groupValue === 'input') point.subscriptionInput += value;
+    if (bucket.groupValue === 'output') point.subscriptionOutput += value;
   });
 
   const points = Array.from(byTimestamp.values())
     .map((point) => ({ ...point, uncached: Math.max(0, point.uncached - point.cached) }))
     .sort((left, right) => left.timestamp - right.timestamp);
 
-  return fillTimeBuckets(points, granularity, range, (timestamp) => ({
-    timestamp,
-    uncached: 0,
-    cached: 0,
-    output: 0,
-  }));
+  return fillTimeBuckets(points, granularity, range, emptyPoint);
 }
 
 export function LlmSection({ organizationId, range }: { organizationId: string; range: UsageRange | null }) {
@@ -125,6 +184,9 @@ export function LlmSection({ organizationId, range }: { organizationId: string; 
   const inputTotal = sumBuckets(byKey['llm-input-total']);
   const cachedTotal = sumBuckets(byKey['llm-cached-total']);
   const outputTotal = sumBuckets(byKey['llm-output-total']);
+  const subscriptionInputTotal = sumBuckets(byKey['llm-subscription-input-total']);
+  const subscriptionOutputTotal = sumBuckets(byKey['llm-subscription-output-total']);
+  const subscriptionTotal = subscriptionInputTotal + subscriptionOutputTotal;
 
   const requestTotals = identifiedGroupTotals(byKey['llm-requests-total']?.data?.buckets ?? []);
   const succeeded = microsToNumber(requestTotals.get('success') ?? 0n);
@@ -132,7 +194,15 @@ export function LlmSection({ organizationId, range }: { organizationId: string; 
   const requestsTotal = succeeded + failed;
 
   const tokenSeries = useMemo(
-    () => (range ? buildTokenSeries(byKey['llm-daily-tokens']?.data?.buckets ?? [], granularity, range) : []),
+    () =>
+      range
+        ? buildTokenSeries(
+            byKey['llm-daily-tokens']?.data?.buckets ?? [],
+            byKey['llm-subscription-daily-tokens']?.data?.buckets ?? [],
+            granularity,
+            range,
+          )
+        : [],
     [byKey, granularity, range],
   );
 
@@ -147,16 +217,28 @@ export function LlmSection({ organizationId, range }: { organizationId: string; 
   }, [modelsQuery.data?.models]);
 
   // Models are a resource, not a consumer level, so they are summed here rather
-  // than through the ranking machinery the Group by control drives.
+  // than through the ranking machinery the Group by control drives. The two
+  // sides key differently -- a Model UUID against the model_name a native call
+  // reports -- so each is resolved against the one that owns it.
   const modelRows: ConsumerRow[] = useMemo(() => {
-    const merged = new Map<string, bigint>();
+    const rows = new Map<string, ConsumerRow>();
+    const add = (id: string, label: string, detail: string, value: bigint) => {
+      const row = rows.get(id) ?? { id, label, detail, value: 0 };
+      rows.set(id, { ...row, value: row.value + microsToNumber(value) });
+    };
+
     [byKey['llm-models-input-total'], byKey['llm-models-output-total']].forEach((query) => {
       identifiedGroupTotals(query?.data?.buckets ?? []).forEach((value, id) => {
-        merged.set(id, (merged.get(id) ?? 0n) + value);
+        add(id, modelNames.get(id) ?? id, 'Model', value);
       });
     });
-    return Array.from(merged.entries())
-      .map(([id, value]) => ({ id, label: modelNames.get(id) ?? id, detail: 'Model', value: microsToNumber(value) }))
+    [byKey['llm-subscription-models-input-total'], byKey['llm-subscription-models-output-total']].forEach((query) => {
+      identifiedGroupTotals(query?.data?.buckets ?? []).forEach((value, name) => {
+        add(`subscription:${name}`, name, 'Subscription', value);
+      });
+    });
+
+    return Array.from(rows.values())
       .sort((left, right) => right.value - left.value)
       .slice(0, 5);
   }, [byKey, modelNames]);
@@ -170,12 +252,15 @@ export function LlmSection({ organizationId, range }: { organizationId: string; 
     );
   }
 
-  const tokensEmpty = tokenSeries.every((point) => !point.uncached && !point.cached && !point.output);
+  const tokensEmpty = tokenSeries.every(
+    (point) =>
+      !point.uncached && !point.cached && !point.output && !point.subscriptionInput && !point.subscriptionOutput,
+  );
   const rangeLabel = formatRangeLabel(range.start, range.end);
 
   return (
     <div className="space-y-4" data-testid="organization-usage-llm-section">
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4" data-testid="organization-usage-llm-metrics">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5" data-testid="organization-usage-llm-metrics">
         <UsageMetricCard
           label="Input tokens"
           value={formatUsageValue(inputTotal)}
@@ -195,6 +280,17 @@ export function LlmSection({ organizationId, range }: { organizationId: string; 
           isLoading={byKey['llm-output-total']?.isPending ?? true}
           isError={byKey['llm-output-total']?.isError ?? false}
           testId="organization-usage-llm-output"
+        />
+        <UsageMetricCard
+          label="Subscription tokens"
+          value={formatUsageValue(subscriptionTotal)}
+          // Named as not billed rather than left off the tab: a flat fee is not
+          // zero usage, and the figures beside it cover only what is charged.
+          // The input/output split is in the chart below, which has room for it.
+          helper="Flat fee, not billed"
+          isLoading={byKey['llm-subscription-input-total']?.isPending ?? true}
+          isError={byKey['llm-subscription-input-total']?.isError ?? false}
+          testId="organization-usage-llm-subscription"
         />
         <UsageMetricCard
           label="Requests"
@@ -232,6 +328,7 @@ export function LlmSection({ organizationId, range }: { organizationId: string; 
             items={[
               { label: 'Uncached input', color: 'var(--color-chart-1)' },
               { label: 'Cached input', color: 'var(--color-chart-2)' },
+              { label: 'Subscription (not billed)', color: 'var(--color-chart-4)' },
             ]}
           />
         </UsageChartCard>
@@ -334,6 +431,16 @@ function TokenPanels({ series, granularity }: { series: TokenPoint[]; granularit
               { label: 'Uncached input', color: 'var(--color-chart-1)', value: formatUsageNumber(point.uncached) },
               { label: 'Cached input', color: 'var(--color-chart-2)', value: formatUsageNumber(point.cached) },
               { label: 'Output', color: 'var(--color-chart-3)', value: formatUsageNumber(point.output) },
+              {
+                label: 'Subscription in',
+                color: 'var(--color-chart-4)',
+                value: formatUsageNumber(point.subscriptionInput),
+              },
+              {
+                label: 'Subscription out',
+                color: 'var(--color-chart-4)',
+                value: formatUsageNumber(point.subscriptionOutput),
+              },
             ]}
           />
         );
@@ -370,6 +477,14 @@ function TokenPanels({ series, granularity }: { series: TokenPoint[]; granularit
             stackId="input"
             fill="var(--color-chart-2)"
             maxBarSize={18}
+            shape={<BarShape stacked />}
+            isAnimationActive={false}
+          />
+          <Bar
+            dataKey="subscriptionInput"
+            stackId="input"
+            fill="var(--color-chart-4)"
+            maxBarSize={18}
             shape={<BarShape capped />}
             isAnimationActive={false}
           />
@@ -401,7 +516,16 @@ function TokenPanels({ series, granularity }: { series: TokenPoint[]; granularit
           <Tooltip cursor={cursor} content={() => null} />
           <Bar
             dataKey="output"
+            stackId="output"
             fill="var(--color-chart-3)"
+            maxBarSize={18}
+            shape={<BarShape stacked />}
+            isAnimationActive={false}
+          />
+          <Bar
+            dataKey="subscriptionOutput"
+            stackId="output"
+            fill="var(--color-chart-4)"
             maxBarSize={18}
             shape={<BarShape capped />}
             isAnimationActive={false}
@@ -413,7 +537,9 @@ function TokenPanels({ series, granularity }: { series: TokenPoint[]; granularit
 }
 
 function TokenTable({ series, granularity }: { series: TokenPoint[]; granularity: Granularity }) {
-  const rows = series.filter((point) => point.uncached || point.cached || point.output);
+  const rows = series.filter(
+    (point) => point.uncached || point.cached || point.output || point.subscriptionInput || point.subscriptionOutput,
+  );
   return (
     <div className="max-h-60 overflow-auto">
       <table className="w-full text-xs">
@@ -423,6 +549,8 @@ function TokenTable({ series, granularity }: { series: TokenPoint[]; granularity
             <th className="px-2 py-1.5 text-right font-medium">Uncached</th>
             <th className="px-2 py-1.5 text-right font-medium">Cached</th>
             <th className="px-2 py-1.5 text-right font-medium">Output</th>
+            <th className="px-2 py-1.5 text-right font-medium">Sub. in</th>
+            <th className="px-2 py-1.5 text-right font-medium">Sub. out</th>
           </tr>
         </thead>
         <tbody>
@@ -432,6 +560,8 @@ function TokenTable({ series, granularity }: { series: TokenPoint[]; granularity
               <td className="px-2 py-1.5 text-right tabular-nums">{formatUsageNumber(point.uncached)}</td>
               <td className="px-2 py-1.5 text-right tabular-nums">{formatUsageNumber(point.cached)}</td>
               <td className="px-2 py-1.5 text-right tabular-nums">{formatUsageNumber(point.output)}</td>
+              <td className="px-2 py-1.5 text-right tabular-nums">{formatUsageNumber(point.subscriptionInput)}</td>
+              <td className="px-2 py-1.5 text-right tabular-nums">{formatUsageNumber(point.subscriptionOutput)}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
The Overview read 143.9K tokens where Usage read 95, for the same
organization over the same week. Two separate faults, one on each page.

The Overview summed every token record it was given. Cached tokens are the
share of the input served from cache, not tokens spent on top of it -- the
LLM tab draws them as `input - cached` for exactly that reason -- so the
headline counted them twice and came out two thirds larger than the traffic
behind it. The figure now groups by kind and adds input and output only;
metering filters by equality, so naming the kinds means grouping by them.

The rest of the gap is subscription tokens. Every token query on the Usage
tab filters to resource=model on purpose: a subscription is a flat fee, and
summing its tokens produces a bill that does not exist. But an organization
running in native mode spends nearly all of its tokens that way, and the tab
answered with an empty state while the Overview counted the same calls.
Subscription usage is now read on its own and shown beside the billable
figures as what it is -- a card, a series in the token chart, and rows in the
tooltip and table, each marked not billed.

By model covers both. A native call runs against a Subscription and carries
no Model to resolve, so those rows key on the model_name the proxy records
rather than a UUID that would render raw.

The spend queries and the consumer rankings are untouched. The test that
guarded them asked that every token query filter to resource=model; it now
asks that every token query name a resource, with the rankings pinned to
model separately, so an unfiltered query still cannot mix the two back
together.