### PR TITLE
Sign out against providers with no end session endpoint

### DIFF
--- a/src/auth/sign-out.test.ts
+++ b/src/auth/sign-out.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getMetadata = vi.fn();
+
+vi.mock('./user-manager', () => ({
+  userManager: { metadataService: { getMetadata } },
+}));
+
+const { signOutAtProvider } = await import('./sign-out');
+
+describe('signOutAtProvider', () => {
+  beforeEach(() => {
+    getMetadata.mockReset();
+  });
+
+  it('redirects when the provider publishes an end session endpoint', async () => {
+    getMetadata.mockResolvedValue({ end_session_endpoint: 'https://auth.agyn.dev:2496/logout' });
+    const signoutRedirect = vi.fn().mockResolvedValue(undefined);
+
+    await signOutAtProvider(signoutRedirect);
+
+    expect(signoutRedirect).toHaveBeenCalledOnce();
+  });
+
+  // Dex publishes none and holds no browser session, so the local sign-out the
+  // caller already did is the whole sign-out. Redirecting anyway throws, and the
+  // app renders that as a sign-in failure.
+  it('does nothing when the provider publishes no end session endpoint', async () => {
+    getMetadata.mockResolvedValue({ issuer: 'https://dex.agyn.dev:2496' });
+    const signoutRedirect = vi.fn().mockResolvedValue(undefined);
+
+    await signOutAtProvider(signoutRedirect);
+
+    expect(signoutRedirect).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when discovery cannot be read', async () => {
+    getMetadata.mockRejectedValue(new Error('network down'));
+    const signoutRedirect = vi.fn().mockResolvedValue(undefined);
+
+    await signOutAtProvider(signoutRedirect);
+
+    expect(signoutRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/auth/sign-out.ts
+++ b/src/auth/sign-out.ts
@@ -1,0 +1,30 @@
+import { userManager } from './user-manager';
+
+// Keycloak publishes end_session_endpoint and keeps a browser session that only
+// the redirect can end. Dex publishes neither, and signoutRedirect() throws on
+// the missing endpoint -- react-oidc-context catches that into auth.error, so a
+// sign-out that already succeeded renders the sign-in failure screen instead of
+// the signed-out one.
+//
+// Discovery being unreachable counts as absent: the local sign-out has already
+// happened by the time this is asked, and there is nothing to gain from failing.
+async function supportsProviderSignOut(): Promise<boolean> {
+  if (!userManager) return false;
+  try {
+    const metadata = await userManager.metadataService.getMetadata();
+    return Boolean(metadata.end_session_endpoint);
+  } catch (error) {
+    console.warn('Could not read OIDC discovery; signing out locally.', error);
+    return false;
+  }
+}
+
+/**
+ * Ends the session at the provider, for providers that hold one. The caller has
+ * already signed out locally, so this is a no-op wherever there is nothing to
+ * end.
+ */
+export async function signOutAtProvider(signoutRedirect: () => Promise<void>): Promise<void> {
+  if (!(await supportsProviderSignOut())) return;
+  await signoutRedirect();
+}

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -6,6 +6,7 @@ import { useAuth } from 'react-oidc-context';
 import { usersClient } from '@/api/client';
 import { oidcConfig } from '@/config';
 import { setSignedOutFlag } from '@/auth/signed-out';
+import { signOutAtProvider } from '@/auth/sign-out';
 import type { User } from '@/gen/agynio/api/users/v1/users_pb';
 import { ClusterRole } from '@/gen/agynio/api/users/v1/users_pb';
 
@@ -97,7 +98,7 @@ function OidcUserProvider({ children }: { children: ReactNode }) {
       void auth.removeUser().catch((removeError) => {
         console.warn('Failed to clear OIDC user session.', removeError);
       });
-      void auth.signoutRedirect().catch((signoutError) => {
+      void signOutAtProvider(() => auth.signoutRedirect()).catch((signoutError) => {
         console.warn('OIDC sign-out redirect failed.', signoutError);
       });
     },


### PR DESCRIPTION
`signoutRedirect()` throws when discovery carries no `end_session_endpoint`, and react-oidc-context turns that into `auth.error` — which outranks the signed-out screen, so a sign-out that had already cleared the session rendered a sign-in failure.

Providers differ: Keycloak publishes the endpoint and holds a browser session only the redirect can end; Dex publishes neither. Ask discovery which one this is, and skip the redirect where there is no session to end.

Three tests cover the branches: endpoint present → redirect, absent → local sign-out, discovery unreachable → local sign-out.