### PR TITLE
Take sibling product addresses from configuration

### DIFF
--- a/charts/console-app/values.yaml
+++ b/charts/console-app/values.yaml
@@ -83,6 +83,9 @@ env:
     value: "{{ .Values.oidcResource }}"
   - name: API_BASE_URL
     value: "{{ .Values.apiBaseUrl }}"
+# CHAT_URL, TRACING_URL, CONSOLE_URL and SANDBOXES_URL are deliberately absent:
+# an explicit empty env var shadows extraEnvVarsCM, which is how the umbrella
+# feeds them. Set them here via extraEnvVars for a standalone install.
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""

--- a/docker/40-generate-env.sh
+++ b/docker/40-generate-env.sh
@@ -8,6 +8,10 @@ escape_js() {
 }
 
 api_base_url=$(escape_js "${API_BASE_URL:-}")
+chat_url=$(escape_js "${CHAT_URL:-}")
+tracing_url=$(escape_js "${TRACING_URL:-}")
+console_url=$(escape_js "${CONSOLE_URL:-}")
+sandboxes_url=$(escape_js "${SANDBOXES_URL:-}")
 oidc_authority=$(escape_js "${OIDC_AUTHORITY:-}")
 oidc_client_id=$(escape_js "${OIDC_CLIENT_ID:-}")
 oidc_scope=$(escape_js "${OIDC_SCOPE:-}")
@@ -16,6 +20,10 @@ oidc_resource=$(escape_js "${OIDC_RESOURCE:-}")
 cat > "$CONFIG_PATH" <<EOF
 window.__ENV__ = {
   API_BASE_URL: "${api_base_url}",
+  CHAT_URL: "${chat_url}",
+  TRACING_URL: "${tracing_url}",
+  CONSOLE_URL: "${console_url}",
+  SANDBOXES_URL: "${sandboxes_url}",
   OIDC_AUTHORITY: "${oidc_authority}",
   OIDC_CLIENT_ID: "${oidc_client_id}",
   OIDC_SCOPE: "${oidc_scope}",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,9 @@
 type RuntimeEnv = {
   API_BASE_URL?: string;
+  CHAT_URL?: string;
+  TRACING_URL?: string;
+  CONSOLE_URL?: string;
+  SANDBOXES_URL?: string;
   OIDC_AUTHORITY?: string;
   OIDC_CLIENT_ID?: string;
   OIDC_SCOPE?: string;
@@ -60,8 +64,23 @@ export const oidcConfig: OidcConfig = oidcConfigured
     }
   : { enabled: false };
 
+// Sibling product origins, keyed by product id. Set by the operator when the
+// apps are not served at <product>.<domain>; null falls back to derivation.
+const productUrls: Record<string, string | null> = {
+  chat: readProductUrl('CHAT_URL', 'VITE_CHAT_URL'),
+  tracing: readProductUrl('TRACING_URL', 'VITE_TRACING_URL'),
+  console: readProductUrl('CONSOLE_URL', 'VITE_CONSOLE_URL'),
+  sandboxes: readProductUrl('SANDBOXES_URL', 'VITE_SANDBOXES_URL'),
+};
+
+function readProductUrl(runtimeKey: keyof RuntimeEnv, envKey: keyof ImportMetaEnv): string | null {
+  const value = readConfigValue(runtimeKey, envKey);
+  return value ? stripTrailingSlash(value) : null;
+}
+
 export const config = {
   apiBaseUrl,
+  productUrls,
 };
 
 /**

--- a/src/lib/products.test.ts
+++ b/src/lib/products.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Product } from './products';
 
 type WindowStub = {
   location: { protocol: string; hostname: string; port: string };
@@ -20,8 +21,8 @@ async function loadProducts() {
   return { PRODUCTS, productUrl };
 }
 
-function product(id: string, PRODUCTS: { id: string }[]) {
-  return PRODUCTS.find((entry) => entry.id === id)!;
+function product(id: string, products: Product[]): Product {
+  return products.find((entry) => entry.id === id)!;
 }
 
 afterEach(() => {

--- a/src/lib/products.test.ts
+++ b/src/lib/products.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type WindowStub = {
+  location: { protocol: string; hostname: string; port: string };
+  __ENV__: Record<string, string>;
+};
+
+function stubWindow(url: string, env: Record<string, string> = {}): void {
+  const parsed = new URL(url);
+  const stub: WindowStub = {
+    location: { protocol: parsed.protocol, hostname: parsed.hostname, port: parsed.port },
+    __ENV__: env,
+  };
+  vi.stubGlobal('window', stub as unknown as Window);
+}
+
+async function loadProducts() {
+  vi.resetModules();
+  const { PRODUCTS, productUrl } = await import('./products');
+  return { PRODUCTS, productUrl };
+}
+
+function product(id: string, PRODUCTS: { id: string }[]) {
+  return PRODUCTS.find((entry) => entry.id === id)!;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('productUrl', () => {
+  it('derives a sibling host when nothing is configured', async () => {
+    stubWindow('https://console.agyn.dev');
+    const { PRODUCTS, productUrl } = await loadProducts();
+    expect(productUrl(product('chat', PRODUCTS))).toBe('https://chat.agyn.dev');
+  });
+
+  // Hosts that do not split at the first label used to derive a stranger.
+  it('uses the configured address instead of guessing', async () => {
+    stubWindow('https://console-agyn.example.com', {
+      CHAT_URL: 'https://chat-agyn.example.com',
+      SANDBOXES_URL: 'https://sandboxes-agyn.example.com',
+    });
+    const { PRODUCTS, productUrl } = await loadProducts();
+    expect(productUrl(product('chat', PRODUCTS))).toBe('https://chat-agyn.example.com');
+    expect(productUrl(product('sandboxes', PRODUCTS))).toBe('https://sandboxes-agyn.example.com');
+  });
+
+  it('falls back to derivation for products left unconfigured', async () => {
+    stubWindow('https://console.agyn.dev', { CHAT_URL: 'https://chat-agyn.example.com' });
+    const { PRODUCTS, productUrl } = await loadProducts();
+    expect(productUrl(product('tracing', PRODUCTS))).toBe('https://tracing.agyn.dev');
+  });
+
+  it('ignores blank values so an empty env var does not win', async () => {
+    stubWindow('https://console.agyn.dev', { CHAT_URL: '   ' });
+    const { PRODUCTS, productUrl } = await loadProducts();
+    expect(productUrl(product('chat', PRODUCTS))).toBe('https://chat.agyn.dev');
+  });
+
+  it('drops a trailing slash so callers can append a path', async () => {
+    stubWindow('https://console.agyn.dev', { CHAT_URL: 'https://chat-agyn.example.com/' });
+    const { PRODUCTS, productUrl } = await loadProducts();
+    expect(productUrl(product('chat', PRODUCTS))).toBe('https://chat-agyn.example.com');
+  });
+});

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1,5 +1,5 @@
 import { Box, MessageCircle, SlidersVertical, TrendingUp, type LucideIcon } from 'lucide-react';
-import { deriveSiblingUrl } from '@/config';
+import { config, deriveSiblingUrl } from '@/config';
 
 export type Product = {
   id: string;
@@ -23,5 +23,6 @@ export const PRODUCTS: Product[] = [
 /** Null when the product is unreleased or the host has no derivable sibling. */
 export function productUrl(product: Product): string | null {
   if (product.comingSoon) return null;
-  return deriveSiblingUrl(product.subdomain);
+  // Derivation only holds when every app sits at <product>.<domain>.
+  return config.productUrls[product.id] ?? deriveSiblingUrl(product.subdomain);
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,9 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_CHAT_URL?: string;
+  readonly VITE_TRACING_URL?: string;
+  readonly VITE_CONSOLE_URL?: string;
+  readonly VITE_SANDBOXES_URL?: string;
   readonly VITE_OIDC_AUTHORITY?: string;
   readonly VITE_OIDC_CLIENT_ID?: string;
   readonly VITE_OIDC_SCOPE?: string;
@@ -13,6 +17,10 @@ interface ImportMeta {
 interface Window {
   __ENV__?: {
     API_BASE_URL?: string;
+    CHAT_URL?: string;
+    TRACING_URL?: string;
+    CONSOLE_URL?: string;
+    SANDBOXES_URL?: string;
     OIDC_AUTHORITY?: string;
     OIDC_CLIENT_ID?: string;
     OIDC_SCOPE?: string;


### PR DESCRIPTION
The product switcher built its links by replacing the first label of the current hostname with the sibling's name, which holds only while every app is served at `<product>.<domain>`. An install at `console-agyn.example` derived `chat.example` — a host that exists nowhere on it — so every entry led to a 404, and the setup wizard's finish link with them.

The image offered no way to correct it: `env.js` carried `API_BASE_URL` and the OIDC settings and nothing else.

Now reads `CHAT_URL`, `TRACING_URL`, `CONSOLE_URL` and `SANDBOXES_URL`, deriving only where one is unset, so default installs and devspace are untouched. The umbrella feeds them through `envFrom` from a ConfigMap it derives from the routes it already declares, which is why the keys are deliberately absent from the chart's `env:` block — an explicit empty variable would shadow the ConfigMap and put the guessing back.

Verified on the local bundle VM with chat pointed at a host that does not exist: the generated `env.js`, served over the real ingress, carried `https://chat-renamed.agyn.dev:2496` where the old code would have derived `https://chat.agyn.dev:2496`.

Five new tests in `src/lib/products.test.ts` cover the preference, the fallback, blank values and trailing slashes.