### PR TITLE
Separate cluster administration from the organization list

### DIFF
--- a/src/__tests__/organization-context.test.tsx
+++ b/src/__tests__/organization-context.test.tsx
@@ -85,13 +85,6 @@ function mockOrganizationLookup(organizations: Array<{ id: string; name: string 
   });
 }
 
-function mockOrganizationList(organizations: Array<{ id: string; name: string }>) {
-  listOrganizations.mockResolvedValue({
-    organizations: organizations.map((org) => create(OrganizationSchema, org)),
-    nextPageToken: '',
-  });
-}
-
 describe('OrganizationContext', () => {
   afterEach(() => {
     cleanup();
@@ -178,7 +171,7 @@ describe('OrganizationContext', () => {
         status: MembershipStatus.ACTIVE,
       }),
     ]);
-    mockOrganizationList([{ id: 'org-1', name: 'Org One' }]);
+    mockOrganizationLookup([{ id: 'org-1', name: 'Org One' }]);
 
     renderWithProviders();
 
@@ -191,7 +184,7 @@ describe('OrganizationContext', () => {
     userContext.isClusterAdmin = true;
 
     mockMemberships([]);
-    mockOrganizationList([]);
+    mockOrganizationLookup([]);
 
     renderWithProviders();
 
@@ -229,11 +222,19 @@ describe('OrganizationContext', () => {
     });
   });
 
-  it('exposes all accessible organizations for cluster admins', async () => {
+  it('exposes only member organizations for cluster admins', async () => {
     userContext.isClusterAdmin = true;
 
-    mockMemberships([]);
-    mockOrganizationList([
+    mockMemberships([
+      create(MembershipSchema, {
+        id: 'membership-1',
+        organizationId: 'org-1',
+        identityId: 'identity-1',
+        role: MembershipRole.MEMBER,
+        status: MembershipStatus.ACTIVE,
+      }),
+    ]);
+    mockOrganizationLookup([
       { id: 'org-1', name: 'Org One' },
       { id: 'org-2', name: 'Org Two' },
     ]);
@@ -241,8 +242,9 @@ describe('OrganizationContext', () => {
     renderWithProviders();
 
     await waitFor(() => {
-      expect(screen.getByTestId('count').textContent).toBe('2');
+      expect(screen.getByTestId('count').textContent).toBe('1');
     });
+    expect(listOrganizations).not.toHaveBeenCalled();
   });
 
   it('tracks pending membership count', async () => {

--- a/src/__tests__/organization-switcher.test.tsx
+++ b/src/__tests__/organization-switcher.test.tsx
@@ -1,0 +1,73 @@
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { useOrganizationContext } from '@/context/OrganizationContext';
+import { ClusterAdministrationMenuItem, OrganizationMenuItems } from '@/components/OrganizationSwitcher';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+
+type OrganizationContextValue = ReturnType<typeof useOrganizationContext>;
+
+let orgContext: OrganizationContextValue;
+
+vi.mock('@/context/OrganizationContext', () => ({
+  useOrganizationContext: () => orgContext,
+}));
+
+function renderMenu(children: React.ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={['/organizations/org-1']}>
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger>menu</DropdownMenuTrigger>
+        <DropdownMenuContent>{children}</DropdownMenuContent>
+      </DropdownMenu>
+    </MemoryRouter>,
+  );
+}
+
+describe('organization switcher menu', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    const orgOne = { id: 'org-1', name: 'Org One' };
+    orgContext = {
+      organizations: [orgOne],
+      memberships: [],
+      pendingMemberships: [],
+      pendingMembershipsCount: 0,
+      contextMode: { mode: 'organization', organization: orgOne },
+      selectedOrganization: orgOne,
+      status: 'ready',
+      error: null,
+      hasConsoleAccess: true,
+      setContextMode: vi.fn(),
+      setSelectedOrganization: vi.fn(),
+    };
+  });
+
+  it('lists organizations without a cluster administration entry', () => {
+    renderMenu(<OrganizationMenuItems onCreateOrganization={() => {}} />);
+
+    expect(screen.getByTestId('org-item-org-1')).toBeTruthy();
+    expect(screen.queryByTestId('org-switcher-cluster')).toBeNull();
+  });
+
+  it('shows no organizations placeholder when the member list is empty', () => {
+    orgContext.organizations = [];
+    orgContext.selectedOrganization = null;
+    orgContext.contextMode = { mode: 'cluster' };
+
+    renderMenu(<OrganizationMenuItems onCreateOrganization={() => {}} />);
+
+    expect(screen.getByText('No organizations')).toBeTruthy();
+  });
+
+  it('switches into cluster administration from its own menu item', () => {
+    renderMenu(<ClusterAdministrationMenuItem />);
+
+    fireEvent.click(screen.getByTestId('org-switcher-cluster'));
+
+    expect(orgContext.setContextMode).toHaveBeenCalledWith({ mode: 'cluster' });
+  });
+});

--- a/src/__tests__/route-guards.test.tsx
+++ b/src/__tests__/route-guards.test.tsx
@@ -1,9 +1,12 @@
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { create } from '@bufbuild/protobuf';
 import type { OrganizationSummary } from '@/context/OrganizationContext';
 import type { useOrganizationContext } from '@/context/OrganizationContext';
 import type { useUserContext } from '@/context/UserContext';
+import { OrganizationSchema } from '@/gen/agynio/api/organizations/v1/organizations_pb';
 import { RequireClusterAdmin, RequireOrganization } from '@/components/RouteGuards';
 
 type UserContextValue = ReturnType<typeof useUserContext>;
@@ -12,6 +15,16 @@ type OrganizationContextValue = ReturnType<typeof useOrganizationContext>;
 let userContext: UserContextValue;
 let orgContext: OrganizationContextValue;
 
+const { getOrganization } = vi.hoisted(() => ({
+  getOrganization: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  organizationsClient: {
+    getOrganization,
+  },
+}));
+
 vi.mock('@/context/UserContext', () => ({
   useUserContext: () => userContext,
 }));
@@ -19,6 +32,23 @@ vi.mock('@/context/UserContext', () => ({
 vi.mock('@/context/OrganizationContext', () => ({
   useOrganizationContext: () => orgContext,
 }));
+
+function renderAt(path: string, element: React.ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/users" element={element} />
+          <Route path="/organizations/:id" element={element} />
+          <Route path="/organizations" element={<div>Org list</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
 
 describe('route guards', () => {
   afterEach(() => {
@@ -47,6 +77,8 @@ describe('route guards', () => {
       setContextMode: vi.fn(),
       setSelectedOrganization: vi.fn(),
     };
+
+    getOrganization.mockReset();
   });
 
   it('redirects non-admin users away from admin routes', () => {
@@ -101,26 +133,18 @@ describe('route guards', () => {
   });
 
   it('redirects when no organization is selected', () => {
-    render(
-      <MemoryRouter initialEntries={['/organizations/org-2']}>
-        <Routes>
-          <Route
-            path="/organizations/:id"
-            element={
-              <RequireOrganization>
-                <div>Org detail</div>
-              </RequireOrganization>
-            }
-          />
-          <Route path="/organizations" element={<div>Org list</div>} />
-        </Routes>
-      </MemoryRouter>,
+    renderAt(
+      '/organizations/org-2',
+      <RequireOrganization>
+        <div>Org detail</div>
+      </RequireOrganization>,
     );
 
     expect(screen.getByText('Org list')).toBeTruthy();
+    expect(getOrganization).not.toHaveBeenCalled();
   });
 
-  it('does not override cluster context on organization routes', () => {
+  it('adopts the deep-linked organization even from cluster context', async () => {
     const orgTwo: OrganizationSummary = {
       id: 'org-2',
       name: 'Org Two',
@@ -129,24 +153,17 @@ describe('route guards', () => {
     orgContext.contextMode = { mode: 'cluster' };
     orgContext.organizations = [orgTwo];
 
-    render(
-      <MemoryRouter initialEntries={['/organizations/org-2']}>
-        <Routes>
-          <Route
-            path="/organizations/:id"
-            element={
-              <RequireOrganization>
-                <div>Org detail</div>
-              </RequireOrganization>
-            }
-          />
-          <Route path="/organizations" element={<div>Org list</div>} />
-        </Routes>
-      </MemoryRouter>,
+    renderAt(
+      '/organizations/org-2',
+      <RequireOrganization>
+        <div>Org detail</div>
+      </RequireOrganization>,
     );
 
     expect(screen.getByText('Org detail')).toBeTruthy();
-    expect(orgContext.setContextMode).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(orgContext.setContextMode).toHaveBeenCalledWith({ mode: 'organization', organization: orgTwo });
+    });
   });
 
   it('syncs context with deep-linked organization routes', async () => {
@@ -163,24 +180,60 @@ describe('route guards', () => {
     orgContext.selectedOrganization = orgOne;
     orgContext.organizations = [orgOne, orgTwo];
 
-    render(
-      <MemoryRouter initialEntries={['/organizations/org-2']}>
-        <Routes>
-          <Route
-            path="/organizations/:id"
-            element={
-              <RequireOrganization>
-                <div>Org detail</div>
-              </RequireOrganization>
-            }
-          />
-          <Route path="/organizations" element={<div>Org list</div>} />
-        </Routes>
-      </MemoryRouter>,
+    renderAt(
+      '/organizations/org-2',
+      <RequireOrganization>
+        <div>Org detail</div>
+      </RequireOrganization>,
     );
 
     await waitFor(() => {
       expect(orgContext.setContextMode).toHaveBeenCalledWith({ mode: 'organization', organization: orgTwo });
     });
+  });
+
+  it('lets cluster admins open organizations they are not a member of', async () => {
+    userContext.isClusterAdmin = true;
+    orgContext.contextMode = { mode: 'cluster' };
+
+    getOrganization.mockResolvedValue({
+      organization: create(OrganizationSchema, { id: 'org-9', name: 'Other Org' }),
+    });
+
+    renderAt(
+      '/organizations/org-9',
+      <RequireOrganization>
+        <div>Org detail</div>
+      </RequireOrganization>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Org detail')).toBeTruthy();
+    });
+    expect(getOrganization).toHaveBeenCalledWith({ id: 'org-9' });
+    await waitFor(() => {
+      expect(orgContext.setContextMode).toHaveBeenCalledWith({
+        mode: 'organization',
+        organization: expect.objectContaining({ id: 'org-9', name: 'Other Org' }),
+      });
+    });
+  });
+
+  it('redirects non-admins away from organizations they are not a member of', () => {
+    const orgOne: OrganizationSummary = {
+      id: 'org-1',
+      name: 'Org One',
+    };
+    orgContext.organizations = [orgOne];
+
+    renderAt(
+      '/organizations/org-9',
+      <RequireOrganization>
+        <div>Org detail</div>
+      </RequireOrganization>,
+    );
+
+    expect(screen.getByText('Org list')).toBeTruthy();
+    expect(getOrganization).not.toHaveBeenCalled();
   });
 });

--- a/src/components/OrganizationSwitcher.tsx
+++ b/src/components/OrganizationSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { PlusIcon } from 'lucide-react';
+import { PlusIcon, ShieldIcon } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   DropdownMenuItem,
@@ -8,10 +8,6 @@ import {
   DropdownMenuRadioItem,
 } from '@/components/ui/dropdown-menu';
 import { useOrganizationContext } from '@/context/OrganizationContext';
-import { useUserContext } from '@/context/UserContext';
-
-/** Sentinel for the cluster context, which is not an organization id. */
-const CLUSTER_VALUE = '__cluster__';
 
 /**
  * Organization items, rendered inside the user menu. Creating an organization
@@ -19,8 +15,7 @@ const CLUSTER_VALUE = '__cluster__';
  * dialog.
  */
 export function OrganizationMenuItems({ onCreateOrganization }: { onCreateOrganization: () => void }) {
-  const { organizations, contextMode, selectedOrganization, setContextMode } = useOrganizationContext();
-  const { isClusterAdmin } = useUserContext();
+  const { organizations, selectedOrganization, setContextMode } = useOrganizationContext();
   const navigate = useNavigate();
   const location = useLocation();
   const sortedOrganizations = useMemo(
@@ -50,6 +45,56 @@ export function OrganizationMenuItems({ onCreateOrganization }: { onCreateOrgani
     return suffix ? `/organizations/${orgId}/${suffix}` : `/organizations/${orgId}`;
   };
 
+  const handleSelect = (orgId: string) => {
+    const org = sortedOrganizations.find((item) => item.id === orgId);
+    if (!org) return;
+    setContextMode({ mode: 'organization', organization: org });
+    navigate(resolveOrganizationPath(org.id));
+  };
+
+  return (
+    <>
+      <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">Organization</DropdownMenuLabel>
+      {/* Radio group, matching the chat and tracing menus: the current context
+          is marked rather than greyed out. */}
+      <DropdownMenuRadioGroup
+        value={selectedOrganization?.id ?? ''}
+        onValueChange={handleSelect}
+        data-testid="org-switcher"
+      >
+        {sortedOrganizations.length === 0 ? (
+          <DropdownMenuItem disabled>No organizations</DropdownMenuItem>
+        ) : null}
+        {sortedOrganizations.map((org) => (
+          <DropdownMenuRadioItem
+            key={org.id}
+            value={org.id}
+            className="data-[state=checked]:font-medium"
+            data-testid={`org-item-${org.id}`}
+          >
+            <span className="truncate" title={org.name}>
+              {org.name}
+            </span>
+          </DropdownMenuRadioItem>
+        ))}
+      </DropdownMenuRadioGroup>
+      <DropdownMenuItem onSelect={onCreateOrganization} data-testid="org-switcher-create">
+        <PlusIcon className="mr-2 h-4 w-4" />
+        Create organization
+      </DropdownMenuItem>
+    </>
+  );
+}
+
+/**
+ * Entry into the cluster administration context. Lives outside the
+ * organization list: it is a mode, not an organization.
+ */
+export function ClusterAdministrationMenuItem() {
+  const { contextMode, setContextMode } = useOrganizationContext();
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const resolveClusterPath = () => {
     if (location.pathname.startsWith('/organizations/')) {
       return '/organizations';
@@ -68,57 +113,19 @@ export function OrganizationMenuItems({ onCreateOrganization }: { onCreateOrgani
     return '/';
   };
 
-  const handleSelect = (orgId: string) => {
-    const org = sortedOrganizations.find((item) => item.id === orgId);
-    if (!org) return;
-    setContextMode({ mode: 'organization', organization: org });
-    navigate(resolveOrganizationPath(org.id));
-  };
-
-  const handleSelectCluster = () => {
+  const handleSelect = () => {
     setContextMode({ mode: 'cluster' });
     navigate(resolveClusterPath());
   };
 
   return (
-    <>
-      <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">Organization</DropdownMenuLabel>
-      {/* Radio group, matching the chat and tracing menus: the current context
-          is marked rather than greyed out. */}
-      <DropdownMenuRadioGroup
-        value={contextMode?.mode === 'cluster' ? CLUSTER_VALUE : selectedOrganization?.id ?? ''}
-        onValueChange={(value) => (value === CLUSTER_VALUE ? handleSelectCluster() : handleSelect(value))}
-        data-testid="org-switcher"
-      >
-        {sortedOrganizations.length === 0 && !isClusterAdmin ? (
-          <DropdownMenuItem disabled>No organizations</DropdownMenuItem>
-        ) : null}
-        {sortedOrganizations.map((org) => (
-          <DropdownMenuRadioItem
-            key={org.id}
-            value={org.id}
-            className="data-[state=checked]:font-medium"
-            data-testid={`org-item-${org.id}`}
-          >
-            <span className="truncate" title={org.name}>
-              {org.name}
-            </span>
-          </DropdownMenuRadioItem>
-        ))}
-        {isClusterAdmin ? (
-          <DropdownMenuRadioItem
-            value={CLUSTER_VALUE}
-            className="data-[state=checked]:font-medium"
-            data-testid="org-switcher-cluster"
-          >
-            Cluster Administration
-          </DropdownMenuRadioItem>
-        ) : null}
-      </DropdownMenuRadioGroup>
-      <DropdownMenuItem onSelect={onCreateOrganization} data-testid="org-switcher-create">
-        <PlusIcon className="mr-2 h-4 w-4" />
-        Create organization
-      </DropdownMenuItem>
-    </>
+    <DropdownMenuItem
+      onSelect={handleSelect}
+      className={contextMode?.mode === 'cluster' ? 'font-medium' : undefined}
+      data-testid="org-switcher-cluster"
+    >
+      <ShieldIcon className="h-4 w-4" />
+      Cluster Administration
+    </DropdownMenuItem>
   );
 }

--- a/src/components/RouteGuards.tsx
+++ b/src/components/RouteGuards.tsx
@@ -1,7 +1,9 @@
 import type { ReactNode } from 'react';
 import { Navigate, useLocation, useParams } from 'react-router-dom';
 import { useEffect } from 'react';
-import { useOrganizationContext } from '@/context/OrganizationContext';
+import { useQuery } from '@tanstack/react-query';
+import { organizationsClient } from '@/api/client';
+import { useOrganizationContext, type OrganizationSummary } from '@/context/OrganizationContext';
 import { useUserContext } from '@/context/UserContext';
 
 type GuardProps = {
@@ -30,22 +32,43 @@ export function RequireClusterAdmin({ children }: GuardProps) {
 }
 
 export function RequireOrganization({ children }: GuardProps) {
-  const { selectedOrganization, status, error, organizations, setContextMode, contextMode } = useOrganizationContext();
+  const { selectedOrganization, status, error, organizations, setContextMode } = useOrganizationContext();
+  const { isClusterAdmin } = useUserContext();
   const location = useLocation();
   const params = useParams();
   const orgId = params.id;
-  const matchingOrganization = orgId ? organizations.find((org) => org.id === orgId) : null;
+  const memberOrganization = orgId ? organizations.find((org) => org.id === orgId) : null;
   const fallback = selectedOrganization ? `/organizations/${selectedOrganization.id}` : '/organizations';
+
+  // Cluster admins may open organizations they are not a member of; the org
+  // is fetched directly since the context only lists memberships.
+  const adminOrganizationQuery = useQuery({
+    queryKey: ['organizations', 'admin-view', orgId],
+    queryFn: () => organizationsClient.getOrganization({ id: orgId ?? '' }),
+    enabled: isClusterAdmin && status === 'ready' && Boolean(orgId) && !memberOrganization,
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const adminOrganization: OrganizationSummary | null =
+    isClusterAdmin && !memberOrganization && adminOrganizationQuery.data?.organization
+      ? {
+          id: adminOrganizationQuery.data.organization.id,
+          name: adminOrganizationQuery.data.organization.name,
+          createdAt: adminOrganizationQuery.data.organization.createdAt,
+        }
+      : null;
+
+  const matchingOrganization = memberOrganization ?? adminOrganization;
 
   useEffect(() => {
     if (status !== 'ready') return;
     if (!orgId) return;
-    if (contextMode?.mode === 'cluster') return;
     if (selectedOrganization?.id === orgId) return;
     if (matchingOrganization) {
       setContextMode({ mode: 'organization', organization: matchingOrganization });
     }
-  }, [contextMode, matchingOrganization, orgId, selectedOrganization, setContextMode, status]);
+  }, [matchingOrganization, orgId, selectedOrganization, setContextMode, status]);
 
   if (status === 'loading') {
     return <div className="text-sm text-muted-foreground">Loading organizations...</div>;
@@ -60,6 +83,9 @@ export function RequireOrganization({ children }: GuardProps) {
   }
 
   if (!matchingOrganization) {
+    if (isClusterAdmin && (adminOrganizationQuery.isPending || adminOrganizationQuery.isFetching)) {
+      return <div className="text-sm text-muted-foreground">Loading organization...</div>;
+    }
     return <Navigate to={fallback} state={{ from: location }} replace />;
   }
 

--- a/src/context/OrganizationContext.tsx
+++ b/src/context/OrganizationContext.tsx
@@ -149,24 +149,11 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
     return Array.from(ids).sort((a, b) => a.localeCompare(b));
   }, [memberships]);
 
+  // Everyone, cluster admins included, sees only the organizations they are a
+  // member of here; admins reach the rest through the administration section.
   const organizationsQuery = useQuery({
-    queryKey: isClusterAdmin
-      ? ['organizations', 'list']
-      : ['organizations', 'by-membership', organizationIds],
+    queryKey: ['organizations', 'by-membership', organizationIds],
     queryFn: async () => {
-      if (isClusterAdmin) {
-        const organizations: Organization[] = [];
-        let pageToken = '';
-        do {
-          const response = await organizationsClient.listOrganizations({
-            pageSize: MAX_PAGE_SIZE,
-            pageToken,
-          });
-          organizations.push(...response.organizations);
-          pageToken = response.nextPageToken;
-        } while (pageToken);
-        return { organizations };
-      }
       if (organizationIds.length === 0) {
         return { organizations: [] };
       }
@@ -178,7 +165,7 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
       );
       return { organizations };
     },
-    enabled: userStatus === 'ready' && Boolean(identityId) && (isClusterAdmin || membershipsQuery.isSuccess),
+    enabled: userStatus === 'ready' && Boolean(identityId) && membershipsQuery.isSuccess,
     staleTime: 60 * 1000,
     refetchOnWindowFocus: false,
   });
@@ -193,10 +180,10 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
     [listedOrganizations, memberships],
   );
 
-  const visibleOrganizations = useMemo(() => {
-    if (isClusterAdmin) return mappedOrganizations;
-    return mappedOrganizations.filter((org) => org.membershipStatus === MembershipStatus.ACTIVE);
-  }, [isClusterAdmin, mappedOrganizations]);
+  const visibleOrganizations = useMemo(
+    () => mappedOrganizations.filter((org) => org.membershipStatus === MembershipStatus.ACTIVE),
+    [mappedOrganizations],
+  );
 
   const sortedOrganizations = useMemo(
     () => [...visibleOrganizations].sort((a, b) => a.name.localeCompare(b.name)),
@@ -231,6 +218,9 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
       if (current?.mode === 'organization') {
         const match = sortedOrganizations.find((org) => org.id === current.organization.id);
         if (match) return { mode: 'organization', organization: match };
+        // A cluster admin may be browsing an organization they are not a
+        // member of; that context is valid even though it is not listed.
+        if (isClusterAdmin) return current;
       }
       if (current?.mode === 'cluster' && isClusterAdmin) {
         return { mode: 'cluster' };

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -18,7 +18,7 @@ import { PendingInvitesMenu } from '@/components/PendingInvitesMenu';
 import { useOrganizationContext } from '@/context/OrganizationContext';
 import { useSetupOverlay } from '@/context/SetupOverlayContext';
 import { useUserContext } from '@/context/UserContext';
-import { OrganizationMenuItems } from '@/components/OrganizationSwitcher';
+import { ClusterAdministrationMenuItem, OrganizationMenuItems } from '@/components/OrganizationSwitcher';
 import { useCreateOrganization } from '@/hooks/useCreateOrganization';
 import { useSidebarGroups } from '@/hooks/useSidebarGroups';
 import { usePageTitle } from '@/context/PageTitleContext';
@@ -196,7 +196,7 @@ export function AppLayout() {
     status: orgStatus,
     error: orgError,
   } = useOrganizationContext();
-  const { currentUser, status: userStatus, error: userError, signOut } = useUserContext();
+  const { currentUser, isClusterAdmin, status: userStatus, error: userError, signOut } = useUserContext();
   const createOrganization = useCreateOrganization();
   const pageTitle = usePageTitle();
   const navigate = useNavigate();
@@ -267,6 +267,12 @@ export function AppLayout() {
       <DropdownMenuContent align="end" className="w-64" data-testid="user-menu">
         {/* The trigger already shows who is signed in and where. */}
         <OrganizationMenuItems onCreateOrganization={() => createOrganization.handleOpenChange(true)} />
+        {isClusterAdmin ? (
+          <>
+            <DropdownMenuSeparator />
+            <ClusterAdministrationMenuItem />
+          </>
+        ) : null}
         {/* PendingInvitesMenu renders nothing without invites, so its divider
             travels with it rather than stacking on the next one. */}
         {pendingMembershipsCount > 0 ? (

--- a/src/pages/OrganizationOverviewTab.tsx
+++ b/src/pages/OrganizationOverviewTab.tsx
@@ -22,9 +22,13 @@ export function OrganizationOverviewTab() {
   const { id } = useParams();
   const organizationId = id ?? '';
   // RequireOrganization has already resolved the URL id against the caller's
-  // organizations, so this lookup needs no request of its own.
-  const { organizations } = useOrganizationContext();
-  const organizationName = organizations.find((organization) => organization.id === organizationId)?.name ?? '';
+  // organizations, so this lookup needs no request of its own. Cluster admins
+  // may be viewing an organization outside their memberships; the guard put it
+  // into the selected context.
+  const { organizations, selectedOrganization } = useOrganizationContext();
+  const organizationName =
+    organizations.find((organization) => organization.id === organizationId)?.name ??
+    (selectedOrganization?.id === organizationId ? selectedOrganization.name : '');
   const notificationRooms = useMemo(
     () => (organizationId ? [`organization:${organizationId}`] : []),
     [organizationId],

--- a/src/pages/OrganizationsListPage.tsx
+++ b/src/pages/OrganizationsListPage.tsx
@@ -1,17 +1,21 @@
+import { useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { BuildingIcon, PlusIcon } from 'lucide-react';
+import { organizationsClient } from '@/api/client';
 import { SortableHeader } from '@/components/SortableHeader';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { CreateOrganizationDialog } from '@/components/CreateOrganizationDialog';
 import { Input } from '@/components/ui/input';
-import { useOrganizationContext } from '@/context/OrganizationContext';
+import { useOrganizationContext, type OrganizationSummary } from '@/context/OrganizationContext';
 import { useUserContext } from '@/context/UserContext';
-import type { MembershipRole } from '@/gen/agynio/api/organizations/v1/organizations_pb';
+import type { MembershipRole, Organization } from '@/gen/agynio/api/organizations/v1/organizations_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useListControls } from '@/hooks/useListControls';
 import { useCreateOrganization } from '@/hooks/useCreateOrganization';
+import { MAX_PAGE_SIZE } from '@/lib/pagination';
 import { formatDateOnly, formatMembershipRole, timestampToMillis } from '@/lib/format';
 
 function describeRole(role?: MembershipRole, isClusterAdmin?: boolean): string {
@@ -22,8 +26,51 @@ function describeRole(role?: MembershipRole, isClusterAdmin?: boolean): string {
 export function OrganizationsListPage() {
   useDocumentTitle('Organizations');
 
-  const { organizations, status, error } = useOrganizationContext();
+  const { organizations: memberOrganizations, memberships, status: orgStatus, error: orgError } = useOrganizationContext();
   const { isClusterAdmin } = useUserContext();
+
+  // The administration view covers every organization on the cluster; the
+  // context deliberately carries only the admin's own memberships.
+  const clusterOrganizationsQuery = useQuery({
+    queryKey: ['organizations', 'list'],
+    queryFn: async () => {
+      const organizations: Organization[] = [];
+      let pageToken = '';
+      do {
+        const response = await organizationsClient.listOrganizations({
+          pageSize: MAX_PAGE_SIZE,
+          pageToken,
+        });
+        organizations.push(...response.organizations);
+        pageToken = response.nextPageToken;
+      } while (pageToken);
+      return organizations;
+    },
+    enabled: isClusterAdmin,
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const organizations = useMemo<OrganizationSummary[]>(() => {
+    if (!isClusterAdmin) return memberOrganizations;
+    const membershipByOrg = new Map(memberships.map((membership) => [membership.organizationId, membership]));
+    return (clusterOrganizationsQuery.data ?? []).map((org) => ({
+      id: org.id,
+      name: org.name,
+      createdAt: org.createdAt,
+      membershipRole: membershipByOrg.get(org.id)?.role,
+      membershipStatus: membershipByOrg.get(org.id)?.status,
+    }));
+  }, [clusterOrganizationsQuery.data, isClusterAdmin, memberOrganizations, memberships]);
+
+  const status = isClusterAdmin
+    ? clusterOrganizationsQuery.isPending
+      ? 'loading'
+      : clusterOrganizationsQuery.error
+        ? 'error'
+        : 'ready'
+    : orgStatus;
+  const error = isClusterAdmin ? clusterOrganizationsQuery.error : orgError;
   const {
     open: createOpen,
     handleOpenChange,


### PR DESCRIPTION
For cluster admins the user menu previously listed every organization on the cluster with a Cluster Administration pseudo-entry inside the same radio group.

- The organization switcher now lists only the caller's member organizations, for admins too; Cluster Administration moved out of the list into its own admin-only menu item.
- The administration Organizations page fetches all cluster organizations itself, so the admin view is unchanged there.
- RequireOrganization lets cluster admins open organizations they are not a member of (fetched via GetOrganization) and adopts the deep-linked org into context, so View from the admin list lands in a fully navigable org, including the Members tab.

Pairs with agynio/authorization#40, which grants cluster admins can_manage_members so the Members tab works on foreign orgs.