### PR TITLE
Provision E2E on the platform VM

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,9 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@84cfcd81fe303450baacb8ab499bb065851ee4ad
-        with:
-          ref: 84cfcd81fe303450baacb8ab499bb065851ee4ad
+        uses: agynio/e2e/.github/actions/provision-vm@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main


### PR DESCRIPTION
The pinned bootstrap action builds a k3d cluster through Terraform, and the provider it needs is no longer served:

```
Error: Failed to install provider
Error while installing agynio/k3d v0.2.3: could not query provider registry
```

Nothing has reached the tests since. DevSpace already points at `agyn-platform`, from #140.

Depends on agynio/e2e#255, which boots an image the upgrade can reach and defaults the suites' namespace to `agyn-platform`.

This gets provisioning working. The Playwright console suite still has its own problem on this platform — it signs in against Dex, and the bundle VM's Dex has no account it can drive — so expect the login specs to need a separate fix.