### PR TITLE
Pick a secret for an image's registry credential

### DIFF
--- a/src/__tests__/organization-images-tab.test.tsx
+++ b/src/__tests__/organization-images-tab.test.tsx
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PageTitleProvider } from '@/context/PageTitleContext';
+import { OrganizationImagesTab } from '@/pages/OrganizationImagesTab';
+
+const { listImages, createImage, deleteImage, listSecrets, createSecret } = vi.hoisted(() => ({
+  listImages: vi.fn(),
+  createImage: vi.fn(),
+  deleteImage: vi.fn(),
+  listSecrets: vi.fn(),
+  createSecret: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  imagesClient: { listImages, createImage, deleteImage },
+  secretsClient: { listSecrets, createSecret },
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function renderTab() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PageTitleProvider>
+        <MemoryRouter initialEntries={['/org-1/images']}>
+          <Routes>
+            <Route path="/:id/images" element={<OrganizationImagesTab />} />
+          </Routes>
+        </MemoryRouter>
+      </PageTitleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('OrganizationImagesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listImages.mockResolvedValue({ images: [] });
+    listSecrets.mockResolvedValue({ secrets: [{ meta: { id: 'sec-1' }, title: 'ghcr token' }] });
+    createImage.mockResolvedValue({ image: { meta: { id: 'img-1' } } });
+    deleteImage.mockResolvedValue({});
+  });
+
+  afterEach(cleanup);
+
+  // The registry password is held by reference, so the dialog offers a secret
+  // rather than a password field.
+  it('offers no password field', async () => {
+    renderTab();
+    await screen.findByTestId('images-empty');
+
+    fireEvent.click(screen.getByTestId('images-register-open'));
+    expect(screen.queryByTestId('images-register-password')).toBeNull();
+    expect(screen.getByTestId('images-register-secret')).toBeTruthy();
+  });
+
+  it('registers an anonymous repository with no reference', async () => {
+    renderTab();
+    await screen.findByTestId('images-empty');
+
+    fireEvent.click(screen.getByTestId('images-register-open'));
+    fireEvent.change(screen.getByTestId('images-register-name'), {
+      target: { value: 'devcontainer-go' },
+    });
+    fireEvent.change(screen.getByTestId('images-register-repository'), {
+      target: { value: 'ghcr.io/agynio/devcontainer-go' },
+    });
+    fireEvent.click(screen.getByTestId('images-register-submit'));
+
+    await waitFor(() => expect(createImage).toHaveBeenCalledTimes(1));
+    expect(createImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: 'org-1',
+        name: 'devcontainer-go',
+        repository: 'ghcr.io/agynio/devcontainer-go',
+        secretId: '',
+      }),
+    );
+    expect(createSecret).not.toHaveBeenCalled();
+    expect(createImage.mock.calls[0][0]).not.toHaveProperty('password');
+  });
+});

--- a/src/__tests__/secret-choice.test.ts
+++ b/src/__tests__/secret-choice.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NEW_SECRET, NO_SECRET, resolveSecretChoice, secretChoiceOf } from '@/lib/secret-choice';
+
+const { createSecret } = vi.hoisted(() => ({ createSecret: vi.fn() }));
+
+vi.mock('@/api/client', () => ({ secretsClient: { createSecret } }));
+
+describe('secret choice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createSecret.mockResolvedValue({ secret: { meta: { id: 'sec-new' } } });
+  });
+
+  it('reads an existing reference back as the selection', () => {
+    expect(secretChoiceOf('sec-1').selection).toBe('sec-1');
+    expect(secretChoiceOf('').selection).toBe(NO_SECRET);
+  });
+
+  it('resolves nothing to an empty id', async () => {
+    const id = await resolveSecretChoice({
+      organizationId: 'org-1',
+      choice: secretChoiceOf(''),
+      fallbackTitle: 'fallback',
+      description: 'unused',
+    });
+    expect(id).toBe('');
+    expect(createSecret).not.toHaveBeenCalled();
+  });
+
+  it('passes an existing reference through untouched', async () => {
+    const id = await resolveSecretChoice({
+      organizationId: 'org-1',
+      choice: secretChoiceOf('sec-1'),
+      fallbackTitle: 'fallback',
+      description: 'unused',
+    });
+    expect(id).toBe('sec-1');
+    expect(createSecret).not.toHaveBeenCalled();
+  });
+
+  // The value reaches the Secrets service and nowhere else: what the resource
+  // is given is the id.
+  it('creates a secret first and returns its id', async () => {
+    const id = await resolveSecretChoice({
+      organizationId: 'org-1',
+      choice: { selection: NEW_SECRET, title: '  ', value: 'hunter2' },
+      fallbackTitle: 'registry password',
+      description: 'Registry password',
+    });
+    expect(id).toBe('sec-new');
+    expect(createSecret).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      title: 'registry password',
+      description: 'Registry password',
+      value: 'hunter2',
+    });
+  });
+});

--- a/src/components/SecretPicker.tsx
+++ b/src/components/SecretPicker.tsx
@@ -1,0 +1,111 @@
+import { useQuery } from '@tanstack/react-query';
+import { secretsClient } from '@/api/client';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { MAX_PAGE_SIZE } from '@/lib/pagination';
+import { NEW_SECRET, NO_SECRET, type SecretChoice } from '@/lib/secret-choice';
+
+type Props = {
+  organizationId: string;
+  choice: SecretChoice;
+  onChange: (choice: SecretChoice) => void;
+  /** Gates the list request, so a dialog that is closed asks for nothing. */
+  enabled?: boolean;
+  label?: string;
+  /** Offers NO_SECRET. Off for a credential that is required. */
+  allowNone?: boolean;
+  noneLabel?: string;
+  valueLabel?: string;
+  titlePlaceholder?: string;
+  /** Prefix for element ids and data-testid, e.g. "images-register-secret". */
+  testId: string;
+  error?: string;
+  valueError?: string;
+  helpText?: string;
+};
+
+/**
+ * Picks the secret a resource holds by reference, or creates one inline. What
+ * is typed here reaches the Secrets service and nowhere else: the resource is
+ * given the id.
+ */
+export function SecretPicker({
+  organizationId,
+  choice,
+  onChange,
+  enabled = true,
+  label = 'Secret',
+  allowNone = false,
+  noneLabel = 'None',
+  valueLabel = 'Value',
+  titlePlaceholder,
+  testId,
+  error,
+  valueError,
+  helpText = 'Stored as a secret and referenced by id. Never shown again.',
+}: Props) {
+  const { data } = useQuery({
+    queryKey: ['secrets', organizationId, 'picker'],
+    queryFn: () => secretsClient.listSecrets({ organizationId, pageSize: MAX_PAGE_SIZE }),
+    enabled: enabled && Boolean(organizationId),
+  });
+
+  const secrets = data?.secrets ?? [];
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <Label htmlFor={testId}>{label}</Label>
+        <Select
+          value={choice.selection}
+          onValueChange={(selection) => onChange({ ...choice, selection })}
+        >
+          <SelectTrigger id={testId} data-testid={testId}>
+            <SelectValue placeholder="Choose a secret, or add one" />
+          </SelectTrigger>
+          <SelectContent>
+            {allowNone ? <SelectItem value={NO_SECRET}>{noneLabel}</SelectItem> : null}
+            <SelectItem value={NEW_SECRET}>Add a new secret…</SelectItem>
+            {secrets.map((secret) => (
+              <SelectItem key={secret.meta?.id} value={secret.meta?.id ?? ''}>
+                {secret.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      </div>
+
+      {choice.selection === NEW_SECRET ? (
+        <div className="space-y-3 rounded-md border border-border p-4">
+          <div className="space-y-1">
+            <Label htmlFor={`${testId}-title`}>Secret name</Label>
+            <Input
+              id={`${testId}-title`}
+              value={choice.title}
+              onChange={(event) => onChange({ ...choice, title: event.target.value })}
+              placeholder={titlePlaceholder}
+              data-testid={`${testId}-title`}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${testId}-value`}>{valueLabel}</Label>
+            <Input
+              id={`${testId}-value`}
+              type="password"
+              value={choice.value}
+              onChange={(event) => onChange({ ...choice, value: event.target.value })}
+              data-testid={`${testId}-value`}
+            />
+            {valueError ? (
+              <p className="text-sm text-destructive">{valueError}</p>
+            ) : (
+              <p className="text-sm text-muted-foreground">{helpText}</p>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/secret-choice.ts
+++ b/src/lib/secret-choice.ts
@@ -1,0 +1,45 @@
+import { secretsClient } from '@/api/client';
+
+// Both are offered in the same Select as the existing secrets, so neither
+// choice means leaving the form and losing what is already typed into it.
+export const NEW_SECRET = '__new__';
+export const NO_SECRET = '__none__';
+
+export type SecretChoice = {
+  /** A secret id, NEW_SECRET, or NO_SECRET. */
+  selection: string;
+  /** Title for the secret to create. Only read when selection is NEW_SECRET. */
+  title: string;
+  /** Value for the secret to create. Only read when selection is NEW_SECRET. */
+  value: string;
+};
+
+export function secretChoiceOf(secretId: string): SecretChoice {
+  return { selection: secretId || NO_SECRET, title: '', value: '' };
+}
+
+/**
+ * resolveSecretChoice settles a choice into the id a resource stores. A new
+ * secret is created first and referenced by id, so the resource holds a
+ * reference either way and the value never reaches the service that owns it.
+ *
+ * Returns an empty string when nothing is referenced.
+ */
+export async function resolveSecretChoice(input: {
+  organizationId: string;
+  choice: SecretChoice;
+  fallbackTitle: string;
+  description: string;
+}): Promise<string> {
+  const { organizationId, choice, fallbackTitle, description } = input;
+  if (choice.selection === NO_SECRET || choice.selection === '') return '';
+  if (choice.selection !== NEW_SECRET) return choice.selection;
+
+  const created = await secretsClient.createSecret({
+    organizationId,
+    title: choice.title.trim() || fallbackTitle,
+    description,
+    value: choice.value,
+  });
+  return created.secret?.meta?.id ?? '';
+}

--- a/src/pages/ImageDetailPage.tsx
+++ b/src/pages/ImageDetailPage.tsx
@@ -1,12 +1,27 @@
+import { useState } from 'react';
 import { NavLink, useParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { imagesClient } from '@/api/client';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { imagesClient, secretsClient } from '@/api/client';
+import { SecretPicker } from '@/components/SecretPicker';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { ImageType, ImageVisibility, ImageVersionState } from '@/gen/agynio/api/images/v1/images_pb';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { EMPTY_PLACEHOLDER, formatDateOnly } from '@/lib/format';
 import { groupVersions } from '@/lib/image-versions';
+import { MAX_PAGE_SIZE } from '@/lib/pagination';
+import { resolveSecretChoice, secretChoiceOf, type SecretChoice } from '@/lib/secret-choice';
 
 const TYPE_LABELS: Partial<Record<ImageType, string>> = {
   [ImageType.WORKSPACE]: 'Workspace',
@@ -18,6 +33,11 @@ export function ImageDetailPage() {
   const { id: organizationIdParam, imageId: imageIdParam } = useParams();
   const organizationId = organizationIdParam ?? '';
   const imageId = imageIdParam ?? '';
+  const queryClient = useQueryClient();
+
+  const [credentialOpen, setCredentialOpen] = useState(false);
+  const [username, setUsername] = useState('');
+  const [secret, setSecret] = useState<SecretChoice>(secretChoiceOf(''));
 
   const imageQuery = useQuery({
     queryKey: ['images', 'detail', imageId],
@@ -35,6 +55,50 @@ export function ImageDetailPage() {
 
   const image = imageQuery.data?.image;
   useDocumentTitle(image?.name ?? 'Image');
+
+  // Editing is the owner's; a public image owned elsewhere is readable here and
+  // nothing more, and its owner's secrets are not listable from this
+  // organization either.
+  const owned = Boolean(image) && image?.organizationId === organizationId;
+
+  // Named rather than shown: the credential is a reference, and its title is
+  // what identifies it on the Secrets tab.
+  const secretsQuery = useQuery({
+    queryKey: ['secrets', organizationId, 'picker'],
+    queryFn: () => secretsClient.listSecrets({ organizationId, pageSize: MAX_PAGE_SIZE }),
+    enabled: owned && Boolean(image?.secretId),
+  });
+
+  const secretTitle =
+    secretsQuery.data?.secrets.find((candidate) => candidate.meta?.id === image?.secretId)?.title ??
+    image?.secretId;
+
+  const updateCredential = useMutation({
+    mutationFn: async () => {
+      const secretId = await resolveSecretChoice({
+        organizationId,
+        choice: secret,
+        fallbackTitle: `${image?.name ?? 'image'} registry`,
+        description: `Registry password for image "${image?.name ?? ''}"`,
+      });
+      void queryClient.invalidateQueries({ queryKey: ['secrets', organizationId] });
+      return imagesClient.updateImage({ id: imageId, username: username.trim(), secretId });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['images'] });
+      setCredentialOpen(false);
+      toast.success('Credential updated');
+    },
+    // The repository is read with the new credential before it is stored, so a
+    // wrong one fails here rather than at the next discovery pass.
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const openCredential = () => {
+    setUsername(image?.username ?? '');
+    setSecret(secretChoiceOf(image?.secretId ?? ''));
+    setCredentialOpen(true);
+  };
 
   const versions = versionsQuery.data?.versions ?? [];
   const { release, other } = groupVersions(versions);
@@ -80,6 +144,25 @@ export function ImageDetailPage() {
                       ? 'Public — every organization on the platform'
                       : 'Internal — this organization only'}
                   </div>
+                </div>
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Credential</div>
+                  <div className="text-sm" data-testid="image-detail-credential">
+                    {image.secretId
+                      ? `${image.username || 'no username'} · ${secretTitle}`
+                      : 'Anonymous — the repository is read without one'}
+                  </div>
+                  {owned ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="px-0"
+                      onClick={openCredential}
+                      data-testid="image-detail-credential-edit"
+                    >
+                      Edit credential
+                    </Button>
+                  ) : null}
                 </div>
                 <div>
                   <div className="text-xs uppercase tracking-wide text-muted-foreground">Discovery</div>
@@ -137,6 +220,54 @@ export function ImageDetailPage() {
               )}
             </CardContent>
           </Card>
+
+          <Dialog open={credentialOpen} onOpenChange={setCredentialOpen}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Edit credential</DialogTitle>
+                <DialogDescription>
+                  The repository is read with the credential you name, so a wrong one fails here
+                  rather than at the next discovery pass.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-3">
+                <div className="space-y-1">
+                  <Label>Username</Label>
+                  <Input
+                    value={username}
+                    onChange={(event) => setUsername(event.target.value)}
+                    placeholder="optional"
+                    data-testid="image-credential-username"
+                  />
+                </div>
+                <SecretPicker
+                  organizationId={organizationId}
+                  enabled={credentialOpen}
+                  choice={secret}
+                  onChange={setSecret}
+                  label="Password"
+                  allowNone
+                  noneLabel="None — the repository is readable anonymously"
+                  valueLabel="Password"
+                  titlePlaceholder={`${image.name} registry`}
+                  testId="image-credential-secret"
+                  helpText="Stored as a secret in this organization and referenced by the image. Never shown again."
+                />
+              </div>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setCredentialOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={() => updateCredential.mutate()}
+                  disabled={updateCredential.isPending}
+                  data-testid="image-credential-submit"
+                >
+                  {updateCredential.isPending ? 'Saving…' : 'Save'}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         </>
       )}
     </div>

--- a/src/pages/OrganizationImagesTab.tsx
+++ b/src/pages/OrganizationImagesTab.tsx
@@ -3,6 +3,7 @@ import { NavLink, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { imagesClient } from '@/api/client';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { SecretPicker } from '@/components/SecretPicker';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import {
@@ -26,6 +27,7 @@ import {
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { formatDateOnly } from '@/lib/format';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
+import { resolveSecretChoice, secretChoiceOf, type SecretChoice } from '@/lib/secret-choice';
 import { toast } from 'sonner';
 
 const ALL_TYPES = 'all';
@@ -52,7 +54,7 @@ type RegisterValues = {
   type: ImageType;
   repository: string;
   username: string;
-  password: string;
+  secret: SecretChoice;
   visibility: ImageVisibility;
   tagFilter: string;
 };
@@ -63,7 +65,7 @@ const emptyValues: RegisterValues = {
   type: ImageType.WORKSPACE,
   repository: '',
   username: '',
-  password: '',
+  secret: secretChoiceOf(''),
   visibility: ImageVisibility.INTERNAL,
   tagFilter: '',
 };
@@ -101,18 +103,28 @@ export function OrganizationImagesTab() {
   }, [images, organizationId, typeFilter]);
 
   const registerMutation = useMutation({
-    mutationFn: (input: RegisterValues) =>
-      imagesClient.createImage({
+    mutationFn: async (input: RegisterValues) => {
+      // The image holds the credential by reference, so a secret typed here is
+      // created first and named by id. The password never reaches this service.
+      const secretId = await resolveSecretChoice({
+        organizationId,
+        choice: input.secret,
+        fallbackTitle: `${input.name.trim()} registry`,
+        description: `Registry password for image "${input.name.trim()}"`,
+      });
+      void queryClient.invalidateQueries({ queryKey: ['secrets', organizationId] });
+      return imagesClient.createImage({
         organizationId,
         name: input.name.trim(),
         description: input.description.trim(),
         type: input.type,
         repository: input.repository.trim(),
         username: input.username.trim(),
-        password: input.password,
+        secretId,
         visibility: input.visibility,
         tagFilter: input.tagFilter.trim(),
-      }),
+      });
+    },
     onSuccess: () => {
       // Versions arrive from a background discovery pass, so the list is
       // refetched rather than assumed complete.
@@ -293,27 +305,28 @@ export function OrganizationImagesTab() {
                 data-testid="images-register-repository"
               />
             </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1">
-                <Label>Username</Label>
-                <Input
-                  value={values.username}
-                  onChange={(event) => setValues({ ...values, username: event.target.value })}
-                  placeholder="optional"
-                  data-testid="images-register-username"
-                />
-              </div>
-              <div className="space-y-1">
-                <Label>Password</Label>
-                <Input
-                  type="password"
-                  value={values.password}
-                  onChange={(event) => setValues({ ...values, password: event.target.value })}
-                  placeholder="optional"
-                  data-testid="images-register-password"
-                />
-              </div>
+            <div className="space-y-1">
+              <Label>Username</Label>
+              <Input
+                value={values.username}
+                onChange={(event) => setValues({ ...values, username: event.target.value })}
+                placeholder="optional"
+                data-testid="images-register-username"
+              />
             </div>
+            <SecretPicker
+              organizationId={organizationId}
+              enabled={registerOpen}
+              choice={values.secret}
+              onChange={(secret) => setValues({ ...values, secret })}
+              label="Password"
+              allowNone
+              noneLabel="None — the repository is readable anonymously"
+              valueLabel="Password"
+              titlePlaceholder={values.name.trim() ? `${values.name.trim()} registry` : undefined}
+              testId="images-register-secret"
+              helpText="Stored as a secret in this organization and referenced by the image. Never shown again."
+            />
             <div className="space-y-1">
               <Label>Visibility</Label>
               <Select


### PR DESCRIPTION
Depends on agynio/api#190 (CI generates from `buf.build/agynio/api`) and pairs with agynio/images#3.

## Register dialog

The password field is gone. The credential is chosen from the organization's secrets, with **add a new secret** in the same Select — the pattern Subscriptions already uses — so creating one never means leaving the form. What is typed reaches the Secrets service; the image is given the id.

An anonymously readable repository picks **None** and the image names no secret.

## Detail page

Adds a credential row and an edit dialog. `UpdateImage` has always accepted a credential change and nothing here ever sent one, so rotating a registry password meant deleting the image and registering it again.

## Shared

`SecretPicker` + `lib/secret-choice.ts` are new and used in both places. Subscriptions still has its own inline copy; folding it in is a follow-up, not this PR.