### PR TITLE
Sign out at the provider before clearing anything locally

### DIFF
--- a/src/__tests__/sign-out-order.test.tsx
+++ b/src/__tests__/sign-out-order.test.tsx
@@ -1,0 +1,114 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Ordering, not behaviour: signoutRedirect() reads the stored user for
+// id_token_hint and removes it itself, so anything that clears first sends Dex a
+// post_logout_redirect_uri with no hint -- which it answers 400 -- and drops
+// isAuthenticated while the session is still live, so the app signs straight back
+// in and the click looks like a page reload.
+
+const signoutRedirect = vi.fn();
+const removeUser = vi.fn();
+const getMetadata = vi.fn();
+const calls: string[] = [];
+const replaceNav = vi.fn();
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({
+    signoutRedirect: () => {
+      calls.push('signoutRedirect');
+      return signoutRedirect();
+    },
+    removeUser: () => {
+      calls.push('removeUser');
+      return removeUser();
+    },
+  }),
+}));
+
+vi.mock('@/auth/user-manager', () => ({
+  userManager: { metadataService: { getMetadata } },
+}));
+
+vi.mock('@/config', () => ({
+  oidcConfig: { enabled: true, authority: 'https://auth.agyn.dev:2496', clientId: 'agyn-console', scope: 'openid', resource: null },
+}));
+
+vi.mock('@/api/client', () => ({
+  usersClient: { getCurrentUser: vi.fn().mockResolvedValue({ user: null, clusterRole: null }) },
+}));
+
+const { UserProvider, useUserContext } = await import('@/context/UserContext');
+
+function SignOutOnMount() {
+  const { signOut } = useUserContext();
+  return (
+    <button type="button" data-testid="go" onClick={() => signOut()}>
+      out
+    </button>
+  );
+}
+
+function renderIt() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <UserProvider>
+        <SignOutOnMount />
+      </UserProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const USER_KEY = 'oidc.user:https://auth.agyn.dev:2496:agyn-console';
+
+describe('signOut ordering', () => {
+  beforeEach(() => {
+    calls.length = 0;
+    signoutRedirect.mockReset().mockResolvedValue(undefined);
+    removeUser.mockReset().mockResolvedValue(undefined);
+    getMetadata.mockReset();
+    window.sessionStorage.clear();
+    window.sessionStorage.setItem(USER_KEY, '{"id_token":"tok"}');
+    // The local path navigates to force a fresh mount, which jsdom cannot do and
+    // will not let be spied on -- location has to be swapped wholesale.
+    replaceNav.mockReset();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { origin: 'https://console.agyn.dev:2496', replace: replaceNav },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('redirects before anything clears the stored user', async () => {
+    getMetadata.mockResolvedValue({ end_session_endpoint: 'https://auth.agyn.dev:2496/logout' });
+
+    const { getByTestId } = renderIt();
+    getByTestId('go').click();
+
+    await waitFor(() => expect(calls).toContain('signoutRedirect'));
+
+    expect(calls[0]).toBe('signoutRedirect');
+    expect(calls).not.toContain('removeUser');
+    // The id_token has to still be there for signoutRedirect() to lift it.
+    expect(window.sessionStorage.getItem(USER_KEY)).not.toBeNull();
+  });
+
+  it('signs out locally when the provider holds no session', async () => {
+    getMetadata.mockResolvedValue({ issuer: 'https://auth.agyn.dev:2496' });
+
+    const { getByTestId } = renderIt();
+    getByTestId('go').click();
+
+    await waitFor(() => expect(calls).toContain('removeUser'));
+
+    expect(calls).not.toContain('signoutRedirect');
+    expect(window.sessionStorage.getItem(USER_KEY)).toBeNull();
+    expect(replaceNav).toHaveBeenCalledWith('https://console.agyn.dev:2496');
+  });
+});

--- a/src/auth/sign-out.test.ts
+++ b/src/auth/sign-out.test.ts
@@ -13,23 +13,26 @@ describe('signOutAtProvider', () => {
     getMetadata.mockReset();
   });
 
-  it('redirects when the provider publishes an end session endpoint', async () => {
+  // Reports the redirect so the caller can tell a sign-out that navigated from
+  // one that still owes a local clear. Clearing on both paths is the bug this
+  // guards: signoutRedirect() needs the stored id_token for id_token_hint.
+  it('redirects and reports it when the provider publishes an end session endpoint', async () => {
     getMetadata.mockResolvedValue({ end_session_endpoint: 'https://auth.agyn.dev:2496/logout' });
     const signoutRedirect = vi.fn().mockResolvedValue(undefined);
 
-    await signOutAtProvider(signoutRedirect);
+    await expect(signOutAtProvider(signoutRedirect)).resolves.toBe(true);
 
     expect(signoutRedirect).toHaveBeenCalledOnce();
   });
 
-  // Dex publishes none and holds no browser session, so the local sign-out the
-  // caller already did is the whole sign-out. Redirecting anyway throws, and the
-  // app renders that as a sign-in failure.
+  // A provider that holds no browser session has nothing to end, so the caller's
+  // local sign-out is the whole sign-out. Redirecting anyway throws, and the app
+  // renders that as a sign-in failure.
   it('does nothing when the provider publishes no end session endpoint', async () => {
     getMetadata.mockResolvedValue({ issuer: 'https://dex.agyn.dev:2496' });
     const signoutRedirect = vi.fn().mockResolvedValue(undefined);
 
-    await signOutAtProvider(signoutRedirect);
+    await expect(signOutAtProvider(signoutRedirect)).resolves.toBe(false);
 
     expect(signoutRedirect).not.toHaveBeenCalled();
   });
@@ -38,7 +41,7 @@ describe('signOutAtProvider', () => {
     getMetadata.mockRejectedValue(new Error('network down'));
     const signoutRedirect = vi.fn().mockResolvedValue(undefined);
 
-    await signOutAtProvider(signoutRedirect);
+    await expect(signOutAtProvider(signoutRedirect)).resolves.toBe(false);
 
     expect(signoutRedirect).not.toHaveBeenCalled();
   });

--- a/src/auth/sign-out.ts
+++ b/src/auth/sign-out.ts
@@ -20,11 +20,15 @@ async function supportsProviderSignOut(): Promise<boolean> {
 }
 
 /**
- * Ends the session at the provider, for providers that hold one. The caller has
- * already signed out locally, so this is a no-op wherever there is nothing to
- * end.
+ * Ends the session at the provider, for providers that hold one. Reports whether
+ * it redirected, so the caller knows whether a local sign-out is still owed.
+ *
+ * The stored user has to outlive this call: signoutRedirect() reads its id_token
+ * for id_token_hint and removes the user itself, and Dex answers 400 to a
+ * post_logout_redirect_uri that arrives without the hint.
  */
-export async function signOutAtProvider(signoutRedirect: () => Promise<void>): Promise<void> {
-  if (!(await supportsProviderSignOut())) return;
+export async function signOutAtProvider(signoutRedirect: () => Promise<void>): Promise<boolean> {
+  if (!(await supportsProviderSignOut())) return false;
   await signoutRedirect();
+  return true;
 }

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -82,25 +82,37 @@ function OidcUserProvider({ children }: { children: ReactNode }) {
     status,
     error,
     signOut: () => {
-      try {
-        setSignedOutFlag();
-        const keysToRemove: string[] = [];
-        for (let i = 0; i < window.sessionStorage.length; i += 1) {
-          const key = window.sessionStorage.key(i);
-          if (key?.startsWith('oidc.user:')) {
-            keysToRemove.push(key);
-          }
+      setSignedOutFlag();
+      void (async () => {
+        // The provider goes first, and nothing local is cleared before it:
+        // signoutRedirect() takes id_token_hint from the stored user and removes
+        // it itself. Clearing up front cost the hint -- which Dex rejects -- and
+        // dropped isAuthenticated while the session was still live, so RequireAuth
+        // signed straight back in and sign-out looked like a page reload.
+        try {
+          if (await signOutAtProvider(() => auth.signoutRedirect())) return;
+        } catch (signoutError) {
+          console.warn('OIDC sign-out redirect failed.', signoutError);
         }
-        keysToRemove.forEach((key) => window.sessionStorage.removeItem(key));
-      } catch (removeError) {
-        console.warn('Failed to clear OIDC session storage.', removeError);
-      }
-      void auth.removeUser().catch((removeError) => {
-        console.warn('Failed to clear OIDC user session.', removeError);
-      });
-      void signOutAtProvider(() => auth.signoutRedirect()).catch((signoutError) => {
-        console.warn('OIDC sign-out redirect failed.', signoutError);
-      });
+        try {
+          const keysToRemove: string[] = [];
+          for (let i = 0; i < window.sessionStorage.length; i += 1) {
+            const key = window.sessionStorage.key(i);
+            if (key?.startsWith('oidc.user:')) {
+              keysToRemove.push(key);
+            }
+          }
+          keysToRemove.forEach((key) => window.sessionStorage.removeItem(key));
+        } catch (removeError) {
+          console.warn('Failed to clear OIDC session storage.', removeError);
+        }
+        await auth.removeUser().catch((removeError) => {
+          console.warn('Failed to clear OIDC user session.', removeError);
+        });
+        // Nothing navigated on this path, and the signed-out flag is only read at
+        // mount, so come back through a fresh load.
+        window.location.replace(window.location.origin);
+      })();
     },
   };
 


### PR DESCRIPTION
Split out of #147, which is red for an unrelated reason: `e13ee47` needs `Environment.persistentShells`, and CI regenerates `src/gen/` from the BSR where that field does not exist yet. This branch carries only the sign-out change, off `main`.

Enabling Dex sessions makes it publish `end_session_endpoint`, which the app reads to decide whether signing out has anywhere to go — so every sign-out became an RP-initiated logout and the ordering started to matter.

`signoutRedirect()` reads the stored user for `id_token_hint` and removes the user itself. Clearing sessionStorage and calling `removeUser()` first only cost the hint — which Dex answers 400 to — and dropped `isAuthenticated` while the session was still live, so `RequireAuth` signed straight back in and the click read as a page reload.

Verified against a Dex build with sessions on, on the local VM: logout to a registered `post_logout_redirect_uri` redirects, an unregistered one is refused 400, and both new assertions fail against the pre-fix `UserContext`.