### PR TITLE
Generate bindings before the dev server starts

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -67,6 +67,10 @@ functions:
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
                   npm ci --no-audit --no-fund
+                  # src/gen is generated and not in the repository, so a tree
+                  # that has never generated syncs none of it and Vite fails to
+                  # resolve the first import it meets.
+                  npm run generate
                   # The released image generates env.js at start from the same
                   # variables; Vite serves public/env.js, which is empty, so
                   # without this the console has no OIDC settings and never

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": "20.x"
   },
   "scripts": {
+    "predev": "npm run generate",
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",


### PR DESCRIPTION
Follow-up to #153. With `src/gen` untracked, a tree that has never generated has no bindings — a fresh clone, or one where a branch switch removed the previously tracked copies — and both dev paths fail on the first import Vite meets:

```
[plugin:vite:import-analysis] Failed to resolve import "@/gen/agynio/api/egress/v1/egress_pb" from "src/lib/egressRules.ts"
```

The Dockerfile and CI both run `npm run generate` already. This adds it to the two paths that did not: the devspace dev container (after `npm ci`, where `buf` is available from `@bufbuild/buf`) and `npm run dev` via `predev`.