### PR TITLE
Read every page of a member's organizations

### DIFF
--- a/src/__tests__/organization-context.test.tsx
+++ b/src/__tests__/organization-context.test.tsx
@@ -336,4 +336,51 @@ describe('OrganizationContext', () => {
       expect(screen.getByTestId('pending-ids').textContent).toBe('pending-1,pending-2');
     });
   });
+
+  // A member of more than one page's worth had the rest silently disappear --
+  // including, for anyone near the boundary, the organization they had just
+  // made and asked to open.
+  it('reads every page of memberships, not just the first', async () => {
+    const onPageTwo = create(MembershipSchema, {
+      id: 'membership-late',
+      organizationId: 'org-late',
+      identityId: 'identity-1',
+      role: MembershipRole.OWNER,
+      status: MembershipStatus.ACTIVE,
+    });
+    listMyMemberships.mockImplementation((request: { status?: MembershipStatus; pageToken?: string }) => {
+      if (request?.status === MembershipStatus.PENDING) {
+        return Promise.resolve({ memberships: [] });
+      }
+      if (!request?.pageToken) {
+        return Promise.resolve({
+          memberships: [
+            create(MembershipSchema, {
+              id: 'membership-early',
+              organizationId: 'org-early',
+              identityId: 'identity-1',
+              role: MembershipRole.OWNER,
+              status: MembershipStatus.ACTIVE,
+            }),
+          ],
+          nextPageToken: 'page-2',
+        });
+      }
+      return Promise.resolve({ memberships: [onPageTwo] });
+    });
+    mockOrganizationLookup([
+      { id: 'org-early', name: 'Org Early' },
+      { id: 'org-late', name: 'Org Late' },
+    ]);
+    window.localStorage.setItem(
+      'console.contextMode',
+      JSON.stringify({ mode: 'organization', organizationId: 'org-late' }),
+    );
+
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected').textContent).toBe('org-late');
+    });
+  });
 });

--- a/src/context/OrganizationContext.tsx
+++ b/src/context/OrganizationContext.tsx
@@ -101,6 +101,25 @@ function mapOrganizations(
   });
 }
 
+// Every page of them, not the first. Which organizations the console will show
+// is decided from this list, and a member of more than one page's worth had the
+// rest silently disappear -- including, for anyone near the boundary, the
+// organization they had just made and asked to open.
+async function listAllMyMemberships(status: MembershipStatus): Promise<{ memberships: Membership[] }> {
+  const memberships: Membership[] = [];
+  let pageToken = '';
+  do {
+    const response = await organizationsClient.listMyMemberships({
+      status,
+      pageSize: MAX_PAGE_SIZE,
+      pageToken,
+    });
+    memberships.push(...response.memberships);
+    pageToken = response.nextPageToken;
+  } while (pageToken);
+  return { memberships };
+}
+
 export function OrganizationProvider({ children }: { children: ReactNode }) {
   const { identityId, isClusterAdmin, status: userStatus } = useUserContext();
   const storedContextRef = useRef<StoredContextMode | null>(readStoredContextMode());
@@ -109,12 +128,7 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
   // Memberships include role/status data used to filter org visibility.
   const membershipsQuery = useQuery({
     queryKey: ['organizations', 'memberships'],
-    queryFn: () =>
-      organizationsClient.listMyMemberships({
-        status: MembershipStatus.ACTIVE,
-        pageSize: MAX_PAGE_SIZE,
-        pageToken: '',
-      }),
+    queryFn: () => listAllMyMemberships(MembershipStatus.ACTIVE),
     enabled: userStatus === 'ready' && Boolean(identityId),
     staleTime: 60 * 1000,
     refetchOnWindowFocus: false,
@@ -122,12 +136,7 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
 
   const pendingMembershipsQuery = useQuery({
     queryKey: ['organizations', 'pendingMemberships'],
-    queryFn: () =>
-      organizationsClient.listMyMemberships({
-        status: MembershipStatus.PENDING,
-        pageSize: MAX_PAGE_SIZE,
-        pageToken: '',
-      }),
+    queryFn: () => listAllMyMemberships(MembershipStatus.PENDING),
     enabled: userStatus === 'ready' && Boolean(identityId),
     staleTime: 60 * 1000,
     refetchOnWindowFocus: false,

--- a/src/pages/agent-detail/AgentSkillsTab.tsx
+++ b/src/pages/agent-detail/AgentSkillsTab.tsx
@@ -23,6 +23,11 @@ import { formatDateOnly, timestampToMillis, truncate } from '@/lib/format';
 import { MAX_PAGE_SIZE } from '@/lib/pagination';
 import { toast } from 'sonner';
 
+// The name is the skill's directory on the agent's filesystem, so the API takes
+// only a slug. Checked here to name the rule rather than surface a server error.
+const SKILL_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$/;
+const SKILL_NAME_HINT = 'Lowercase letters, digits and hyphens, up to 64 characters.';
+
 type AgentSkillsTabProps = {
   agentId: string;
 };
@@ -35,6 +40,7 @@ export function AgentSkillsTab({ agentId }: AgentSkillsTabProps) {
   const [createDescription, setCreateDescription] = useState('');
   const [createNameError, setCreateNameError] = useState('');
   const [createBodyError, setCreateBodyError] = useState('');
+  const [createDescriptionError, setCreateDescriptionError] = useState('');
   const [editOpen, setEditOpen] = useState(false);
   const [editSkillId, setEditSkillId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
@@ -42,6 +48,7 @@ export function AgentSkillsTab({ agentId }: AgentSkillsTabProps) {
   const [editDescription, setEditDescription] = useState('');
   const [editNameError, setEditNameError] = useState('');
   const [editBodyError, setEditBodyError] = useState('');
+  const [editDescriptionError, setEditDescriptionError] = useState('');
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const skillsQuery = useQuery({
@@ -84,6 +91,7 @@ export function AgentSkillsTab({ agentId }: AgentSkillsTabProps) {
       setCreateDescription('');
       setCreateNameError('');
       setCreateBodyError('');
+      setCreateDescriptionError('');
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : 'Failed to create skill.');
@@ -119,18 +127,26 @@ export function AgentSkillsTab({ agentId }: AgentSkillsTabProps) {
   const handleCreate = () => {
     const trimmedName = createName.trim();
     const trimmedBody = createBody.trim();
+    const trimmedDescription = createDescription.trim();
     if (!trimmedName) {
       setCreateNameError('Name is required.');
+    } else if (!SKILL_NAME_PATTERN.test(trimmedName)) {
+      setCreateNameError(SKILL_NAME_HINT);
     }
     if (!trimmedBody) {
       setCreateBodyError('Body is required.');
     }
-    if (!trimmedName || !trimmedBody) return;
+    if (!trimmedDescription) {
+      setCreateDescriptionError('Description is required.');
+    }
+    if (!trimmedName || !SKILL_NAME_PATTERN.test(trimmedName) || !trimmedBody || !trimmedDescription) {
+      return;
+    }
     createSkillMutation.mutate({
       agentId,
       name: trimmedName,
       body: trimmedBody,
-      description: createDescription.trim(),
+      description: trimmedDescription,
     });
   };
 
@@ -146,19 +162,28 @@ export function AgentSkillsTab({ agentId }: AgentSkillsTabProps) {
     setEditDescription(skill.description);
     setEditNameError('');
     setEditBodyError('');
+    setEditDescriptionError('');
     setEditOpen(true);
   };
 
   const handleEditSave = () => {
     const trimmedName = editName.trim();
     const trimmedBody = editBody.trim();
+    const trimmedDescription = editDescription.trim();
     if (!trimmedName) {
       setEditNameError('Name is required.');
+    } else if (!SKILL_NAME_PATTERN.test(trimmedName)) {
+      setEditNameError(SKILL_NAME_HINT);
     }
     if (!trimmedBody) {
       setEditBodyError('Body is required.');
     }
-    if (!trimmedName || !trimmedBody) return;
+    if (!trimmedDescription) {
+      setEditDescriptionError('Description is required.');
+    }
+    if (!trimmedName || !SKILL_NAME_PATTERN.test(trimmedName) || !trimmedBody || !trimmedDescription) {
+      return;
+    }
     if (!editSkillId) {
       toast.error('Missing skill ID.');
       return;
@@ -167,7 +192,7 @@ export function AgentSkillsTab({ agentId }: AgentSkillsTabProps) {
       id: editSkillId,
       name: trimmedName,
       body: trimmedBody,
-      description: editDescription.trim(),
+      description: trimmedDescription,
     });
   };
 
@@ -302,7 +327,7 @@ export function AgentSkillsTab({ agentId }: AgentSkillsTabProps) {
           <DialogHeader>
             <DialogTitle data-testid="agent-skills-create-title">Create skill</DialogTitle>
           <DialogDescription data-testid="agent-skills-create-description">
-            Add a new skill prompt for this agent.
+            Add instructions the agent loads when it needs them.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
@@ -317,7 +342,11 @@ export function AgentSkillsTab({ agentId }: AgentSkillsTabProps) {
               }}
               data-testid="agent-skills-create-name"
             />
-            {createNameError && <p className="text-sm text-destructive">{createNameError}</p>}
+            {createNameError ? (
+              <p className="text-sm text-destructive">{createNameError}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">{SKILL_NAME_HINT}</p>
+            )}
           </div>
           <ScriptEditor
             label="Body"
@@ -334,9 +363,19 @@ export function AgentSkillsTab({ agentId }: AgentSkillsTabProps) {
             <Input
               id="agent-skills-create-description-input"
               value={createDescription}
-              onChange={(event) => setCreateDescription(event.target.value)}
+              onChange={(event) => {
+                setCreateDescription(event.target.value);
+                if (createDescriptionError) setCreateDescriptionError('');
+              }}
               data-testid="agent-skills-create-description-input"
             />
+            {createDescriptionError ? (
+              <p className="text-sm text-destructive">{createDescriptionError}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                When the agent should reach for this skill. It reads this before the body.
+              </p>
+            )}
           </div>
         </div>
           <DialogFooter>
@@ -393,9 +432,19 @@ export function AgentSkillsTab({ agentId }: AgentSkillsTabProps) {
             <Input
               id="agent-skills-edit-description-input"
               value={editDescription}
-              onChange={(event) => setEditDescription(event.target.value)}
+              onChange={(event) => {
+                setEditDescription(event.target.value);
+                if (editDescriptionError) setEditDescriptionError('');
+              }}
               data-testid="agent-skills-edit-description-input"
             />
+            {editDescriptionError ? (
+              <p className="text-sm text-destructive">{editDescriptionError}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                When the agent should reach for this skill. It reads this before the body.
+              </p>
+            )}
           </div>
         </div>
           <DialogFooter>


### PR DESCRIPTION
The console decides which organizations to show from `ListMyMemberships`, and asked for a single page of 200. A member of more than that saw the rest disappear.

It fails worse than it sounds: the context falls back to the first organization alphabetically whenever the persisted choice is not among the ones it can see. So opening a missing organization *by address* quietly rendered a different organization's page — same URL, someone else's data on screen.

Found on the local VM, where the e2e account has 244 active memberships: every console spec that created an organization and navigated to it landed on the alphabetically-first organization instead, and the failures read as missing page elements rather than as the wrong page.

Covered by a unit test that puts the stored organization on the second page; it fails on the old single-page read.