### PR TITLE
Give the paged organization list its own cache key

### DIFF
--- a/src/pages/OrganizationsListPage.tsx
+++ b/src/pages/OrganizationsListPage.tsx
@@ -32,7 +32,12 @@ export function OrganizationsListPage() {
   // The administration view covers every organization on the cluster; the
   // context deliberately carries only the admin's own memberships.
   const clusterOrganizationsQuery = useQuery({
-    queryKey: ['organizations', 'list'],
+    // Its own key, because what it caches is its own shape: every page
+    // flattened into one array, where the pages elsewhere cache a single
+    // response. Sharing the key let whichever screen ran first decide what the
+    // other one read, and reading a response as an array threw where it was
+    // mapped -- taking the whole console down with it.
+    queryKey: ['organizations', 'list', 'all-pages'],
     queryFn: async () => {
       const organizations: Organization[] = [];
       let pageToken = '';


### PR DESCRIPTION
Opening **Users** and then **Organizations** blanks the console.

Both screens cached under `['organizations', 'list']`, but they cache different shapes: `OrganizationsListPage` pages through and stores a flattened **array**, while `UsersListPage` and `RegisterAppDialog` each store a single **response object**. Whichever loaded first decided what the other read, so the organizations page mapped over a response object:

```
Error: (s.data ?? []).map is not a function
```

A render that throws takes the whole console down — the layout unmounts and the page goes blank, sidebar and all.

Found from the trace of `console navigation › opens every platform sidebar section`, which walks Users then Organizations and so hits the collision every time; that walk is the regression guard.