### PR TITLE
Fetch a member's organizations in one call

### DIFF
--- a/src/__tests__/organization-context.test.tsx
+++ b/src/__tests__/organization-context.test.tsx
@@ -14,17 +14,17 @@ import {
 
 type UserContextValue = ReturnType<typeof useUserContext>;
 
-const { listMyMemberships, listOrganizations, getOrganization } = vi.hoisted(() => ({
+const { listMyMemberships, listOrganizations, listAccessibleOrganizations } = vi.hoisted(() => ({
   listMyMemberships: vi.fn(),
   listOrganizations: vi.fn(),
-  getOrganization: vi.fn(),
+  listAccessibleOrganizations: vi.fn(),
 }));
 
 vi.mock('@/api/client', () => ({
   organizationsClient: {
     listMyMemberships,
     listOrganizations,
-    getOrganization,
+    listAccessibleOrganizations,
   },
 }));
 
@@ -78,11 +78,9 @@ function mockMemberships(active: Membership[], pending: Membership[] = []) {
 }
 
 function mockOrganizationLookup(organizations: Array<{ id: string; name: string }>) {
-  const lookup = new Map(organizations.map((org) => [org.id, org]));
-  getOrganization.mockImplementation(({ id }: { id: string }) => {
-    const org = lookup.get(id);
-    return Promise.resolve({ organization: org ? create(OrganizationSchema, org) : undefined });
-  });
+  listAccessibleOrganizations.mockImplementation(() =>
+    Promise.resolve({ organizations: organizations.map((org) => create(OrganizationSchema, org)) }),
+  );
 }
 
 describe('OrganizationContext', () => {
@@ -104,7 +102,7 @@ describe('OrganizationContext', () => {
     window.localStorage.clear();
     listMyMemberships.mockReset();
     listOrganizations.mockReset();
-    getOrganization.mockReset();
+    listAccessibleOrganizations.mockReset();
   });
 
   it('migrates legacy selections into context mode storage', async () => {

--- a/src/context/OrganizationContext.tsx
+++ b/src/context/OrganizationContext.tsx
@@ -150,31 +150,22 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
     () => pendingMembershipsQuery.data?.memberships ?? [],
     [pendingMembershipsQuery.data?.memberships],
   );
-  const organizationIds = useMemo(() => {
-    const ids = new Set<string>();
-    memberships.forEach((membership) => {
-      if (membership.organizationId) ids.add(membership.organizationId);
-    });
-    return Array.from(ids).sort((a, b) => a.localeCompare(b));
-  }, [memberships]);
-
   // Everyone, cluster admins included, sees only the organizations they are a
   // member of here; admins reach the rest through the administration section.
   const organizationsQuery = useQuery({
-    queryKey: ['organizations', 'by-membership', organizationIds],
+    queryKey: ['organizations', 'accessible', identityId],
+    // One call, not one per organization. Asked for individually, a member of
+    // a few hundred organizations opened the console on a few hundred requests
+    // -- repeated whenever the membership list grew a page -- and the browser
+    // spent longer on them than on anything the person came to see.
     queryFn: async () => {
-      if (organizationIds.length === 0) {
+      if (!identityId) {
         return { organizations: [] };
       }
-      const responses = await Promise.all(
-        organizationIds.map((id) => organizationsClient.getOrganization({ id })),
-      );
-      const organizations = responses.flatMap((response) =>
-        response.organization ? [response.organization] : [],
-      );
-      return { organizations };
+      const response = await organizationsClient.listAccessibleOrganizations({ identityId });
+      return { organizations: response.organizations };
     },
-    enabled: userStatus === 'ready' && Boolean(identityId) && membershipsQuery.isSuccess,
+    enabled: userStatus === 'ready' && Boolean(identityId),
     staleTime: 60 * 1000,
     refetchOnWindowFocus: false,
   });


### PR DESCRIPTION
`OrganizationContext` resolved the caller's organizations with one `GetOrganization` per membership. On an installation where the account belongs to 244 organizations, a single console session issued **1213** of them — the fanout repeats whenever the membership list grows a page — and the page becomes unresponsive while they drain.

Found while tracing an unrelated e2e failure: the test's page had stopped issuing any requests of its own, and the trace showed what it was busy with instead.

`ListAccessibleOrganizations` answers the same question in one call. Same data, same shape into `mapOrganizations`; the per-membership id list it used to build is gone with it.